### PR TITLE
Scratchpads: Dynamic position and size, depending on monitor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Nix
+result

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1689068808,
+        "narHash": "sha256-6ixXo3wt24N/melDWjq70UuHQLxGV8jZvooRanIHXw0=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "919d646de7be200f3bf08cb76ae1f09402b6f9b4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1685573264,
+        "narHash": "sha256-Zffu01pONhs/pqH07cjlF10NnMDLok8ix5Uk4rhOnZQ=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "380be19fbd2d9079f677978361792cb25e8a3635",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-22.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.lock
+++ b/flake.lock
@@ -20,16 +20,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1685573264,
-        "narHash": "sha256-Zffu01pONhs/pqH07cjlF10NnMDLok8ix5Uk4rhOnZQ=",
+        "lastModified": 1695416179,
+        "narHash": "sha256-610o1+pwbSu+QuF3GE0NU5xQdTHM3t9wyYhB9l94Cd8=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "380be19fbd2d9079f677978361792cb25e8a3635",
+        "rev": "715d72e967ec1dd5ecc71290ee072bcaf5181ed6",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-22.05",
+        "ref": "nixos-23.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,7 @@
 
   inputs = {
     flake-utils.url = "github:numtide/flake-utils";
-    nixpkgs.url = "github:nixos/nixpkgs/nixos-22.05";
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-23.05";
   };
 
   outputs = { self, nixpkgs, flake-utils, ... }:

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,27 @@
+{
+  description = "pyprland";
+
+  inputs = {
+    flake-utils.url = "github:numtide/flake-utils";
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-22.05";
+  };
+
+  outputs = { self, nixpkgs, flake-utils, ... }:
+  flake-utils.lib.eachDefaultSystem
+  (system:
+  let
+    pkgs = import nixpkgs {
+      inherit system;
+    };
+  in
+  {
+    packages = rec {
+      pyprland = pkgs.poetry2nix.mkPoetryApplication {
+        projectDir = ./.;
+        python = pkgs.python310;
+      };
+      default = pyprland;
+    };
+  }
+  );
+}

--- a/poetry.lock
+++ b/poetry.lock
@@ -1,8 +1,0 @@
-package = []
-
-[metadata]
-lock-version = "1.1"
-python-versions = "^3.10"
-content-hash = "53f2eabc9c26446fbcc00d348c47878e118afc2054778c3c803a0a8028af27d9"
-
-[metadata.files]

--- a/poetry.lock
+++ b/poetry.lock
@@ -1,0 +1,8 @@
+package = []
+
+[metadata]
+lock-version = "1.1"
+python-versions = "^3.10"
+content-hash = "53f2eabc9c26446fbcc00d348c47878e118afc2054778c3c803a0a8028af27d9"
+
+[metadata.files]

--- a/pyprland/plugins/scratchpads.py
+++ b/pyprland/plugins/scratchpads.py
@@ -423,7 +423,8 @@ class Extension(Plugin):  # pylint: disable=missing-class-docstring
                 p = int(s[:-1])
                 if p < 0 or p > 100:
                     raise Exception(f"Percentage must be in range [0; 100], got {p}")
-                return int(monitor[dim] * p / 100)
+                scale = float(monitor["scale"])
+                return int(monitor[dim] / scale * p / 100)
             else:
                 raise Exception(f"Unsupported format for dimension {dim} size, got {s}")
 

--- a/pyprland/plugins/scratchpads.py
+++ b/pyprland/plugins/scratchpads.py
@@ -391,14 +391,14 @@ class Extension(Plugin):  # pylint: disable=missing-class-docstring
 
         await hyprctl(f"focuswindow {addr}")
 
-        size = self._convert_coords(item.conf.get("size"), monitor)
+        size = item.conf.get("size")
         if size:
-            x_size, y_size = size
+            x_size, y_size = self._convert_coords(size, monitor)
             await hyprctl(f"resizewindowpixel exact {x_size} {y_size},{addr}")
 
-        position = self._convert_coords(item.conf.get("position"), monitor)
+        position = item.conf.get("position")
         if position:
-            x_pos, y_pos = position
+            x_pos, y_pos = self._convert_coords(position, monitor)
             x_pos_abs, y_pos_abs = x_pos + monitor["x"], y_pos + monitor["y"]
             await hyprctl(f"movewindowpixel exact {x_pos_abs} {y_pos_abs},{addr}")
 
@@ -415,8 +415,7 @@ class Extension(Plugin):  # pylint: disable=missing-class-docstring
         "10% 20%", monitor 800x600 => 80, 120
         """
 
-        if not coords:
-            return None
+        assert coords, "coords must be non null"
 
         def convert(s, dim):
             if s[-1] == "%":
@@ -434,4 +433,4 @@ class Extension(Plugin):  # pylint: disable=missing-class-docstring
             return convert(x_str, "width"), convert(y_str, "height")
         except Exception as e:
             self.log.error(f"Failed to read coordinates: {e}")
-            return None
+            raise e


### PR DESCRIPTION
Hello. I have two monitors with different sizes and currently scratchpad's windows don't change it's size accordingly. So I've added an option to resize and move window depending on monitor size. In my config it looks like this:
```json
{
  "pyprland": {
    "plugins": [
      "scratchpads"
    ]
  },
  "scratchpads": {
    "term_quake": {
      "command": "wezterm start --class term_quake",
      "position": "0% 0%",
      "size": "100% 50%"
    }
  }
}
```
So on each monitor the position of terminal is at top left corner and it always a half of screen's height. Would you mind adding these options?

I've also add a nix flake, it will allow Nix users to install it directly.