### PR TITLE
Fix log output

### DIFF
--- a/pyprland/plugins/monitors.py
+++ b/pyprland/plugins/monitors.py
@@ -168,9 +168,9 @@ class Extension(CastBoolMixin, Plugin):  # pylint: disable=missing-class-docstri
                 if mon["name"].startswith(monitor_name):
                     mon_info = mon
                     break
-            else:
-                self.log.warning("Monitor %s not found", monitor_name)
-                return
+                else:
+                    self.log.warning("Monitor %s not found", monitor_name)
+                    return
 
             default_command = self.config.get("unknown")
             val = await self._place_single_monitor(mon_info, monitors)


### PR DESCRIPTION
Due to incorrect indentation I never saw this log output, which would have been very helpful when troubleshooting https://github.com/hyprland-community/pyprland/issues/65