### PR TITLE
Add option to specify extra paths for plugins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,156 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/#use-with-ide
+.pdm.toml
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
 # Nix
 result

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Check the [Releases change log](https://github.com/hyprland-community/pyprland/r
 
 - Requires Hyprland >= 0.37
 - [monitors](https://github.com/hyprland-community/pyprland/wiki//monitors)
-  - Drops the `wlr-randr` dependency
+  - Drops the `wlr-randr` dependency (used in `monitors` plugin)
   - simplified the syntax, no need for `()` around a screen name (will try matching the exact name first, then partial description)
 
 ### 2.0

--- a/pyprland/command.py
+++ b/pyprland/command.py
@@ -333,7 +333,7 @@ async def run_client():
     manager = Pyprland()
 
     if sys.argv[1] == "version":
-        print("2.1.4-2")  # Automatically updated version
+        print('2.1.4-3')  # Automatically updated version
         return
 
     if sys.argv[1] in ("--help", "-h", "help"):

--- a/pyprland/command.py
+++ b/pyprland/command.py
@@ -96,7 +96,12 @@ class Pyprland:
         init_pyprland = "pyprland" not in self.plugins
         for name in ["pyprland"] + self.config["pyprland"]["plugins"]:
             if name not in self.plugins:
-                modname = name if "." in name else f"pyprland.plugins.{name}"
+                if "." in name:
+                    modname = name
+                elif "external:" in name:
+                    modname = name.replace("external:", "")
+                else:
+                    modname = f"pyprland.plugins.{name}"
                 try:
                     plug = importlib.import_module(modname).Extension(name)
                     if init:

--- a/pyprland/command.py
+++ b/pyprland/command.py
@@ -90,6 +90,9 @@ class Pyprland:
         """Loads the plugins mentioned in the config.
         If init is `True`, call the `init()` method on each plugin.
         """
+        if "plugin_paths" in self.config["pyprland"]:
+            for plugin_path in self.config["pyprland"]["plugin_paths"]:
+                sys.path.append(plugin_path)
         init_pyprland = "pyprland" not in self.plugins
         for name in ["pyprland"] + self.config["pyprland"]["plugins"]:
             if name not in self.plugins:

--- a/pyprland/command.py
+++ b/pyprland/command.py
@@ -90,8 +90,8 @@ class Pyprland:
         """Loads the plugins mentioned in the config.
         If init is `True`, call the `init()` method on each plugin.
         """
-        if "plugin_paths" in self.config["pyprland"]:
-            for plugin_path in self.config["pyprland"]["plugin_paths"]:
+        if "plugins_paths" in self.config["pyprland"]:
+            for plugin_path in self.config["pyprland"]["plugins_paths"]:
                 sys.path.append(plugin_path)
         init_pyprland = "pyprland" not in self.plugins
         for name in ["pyprland"] + self.config["pyprland"]["plugins"]:


### PR DESCRIPTION
Added an option in `pyprland.toml` that lets you specify extra paths that pypr will search in for plugin modules. 
```
[pyprland]
plugins = [ "somebuiltinplugin", "external:customplugin" ]
plugin_paths = [ "/path/to/custom/plugin/" ]
```
Also fixed a bug that would prevent adding custom plugins at all, even using the more manual methods like installing the plugin using `pip install -e .`. At line 96 there is a statement that checks whether the plugin is specified relatively, and if it isn't, imports the plugin from `pyprland.plugins`.
```
modname = name if "." in name else f"pyprland.plugins.{name}"
```
I added an option to prepend `external:` before the plugin name to explicitly import it from outside `pypland.plugins`. In the case that the statement is actually working as intended this won't break any existing configurations. 
I tested if it works with a single example but haven't written any tests or documentation yet because I wanted to check if this format looks good.

Edit: I also added the default Python .gitignore template so that stuff like pycache isn't tracked by git