### PR TITLE
:bug: Fix toggle scratchpads when wrkpec id is minus

### DIFF
--- a/pyprland/plugins/scratchpads/__init__.py
+++ b/pyprland/plugins/scratchpads/__init__.py
@@ -531,7 +531,7 @@ class Extension(CastBoolMixin, Plugin):  # pylint: disable=missing-class-docstri
     async def _show_transition(self, item, monitor, was_alive):
         "perfoms the transition to visible state"
         animation_type = item.conf.get("animation", "").lower()
-        wrkspc = monitor["activeWorkspace"]["id"]
+        wrkspc = monitor["activeWorkspace"]["name"]
         item.meta["last_shown"] = time.time()
         # Start the transition
         await self.hyprctl(


### PR DESCRIPTION
When define common workspace with a name, for example:
```
bind = $mainMod, X, workspace, name:Browser
```
The id of workspace `Browser`  will be minus. However the `movetoworkspce` will move window to workspace 1 by default if target id is minus. So use name instead of id to make it work.