### PR TITLE
Keep special workspace open when toggle scratchpads

### DIFF
--- a/pyprland/command.py
+++ b/pyprland/command.py
@@ -400,7 +400,7 @@ async def run_client():
     manager = Pyprland()
 
     if sys.argv[1] == "version":
-        print("2.2.8-2")  # Automatically updated version
+        print("2.2.8-6")  # Automatically updated version
         return
 
     if sys.argv[1] == "edit":

--- a/pyprland/command.py
+++ b/pyprland/command.py
@@ -395,7 +395,7 @@ async def run_client():
     manager = Pyprland()
 
     if sys.argv[1] == "version":
-        print("2.2.6-3")  # Automatically updated version
+        print("2.2.6-4")  # Automatically updated version
         return
 
     if sys.argv[1] == "edit":

--- a/pyprland/command.py
+++ b/pyprland/command.py
@@ -395,7 +395,7 @@ async def run_client():
     manager = Pyprland()
 
     if sys.argv[1] == "version":
-        print("2.2.6-4")  # Automatically updated version
+        print("2.2.6-5")  # Automatically updated version
         return
 
     if sys.argv[1] == "edit":

--- a/pyprland/common.py
+++ b/pyprland/common.py
@@ -181,6 +181,10 @@ def get_logger(name="pypr", level=None) -> logging.Logger:
     return logger
 
 
+class VersionInfo(tuple[int, int, int]):
+    pass
+
+
 @dataclass
 class SharedState:
     "Stores commonly requested properties"
@@ -189,6 +193,7 @@ class SharedState:
     active_window: str = ""  # window address
     variables: dict = field(default_factory=dict)
     monitors: list[str] = field(default_factory=list)
+    hyprland_version: VersionInfo = VersionInfo((0, 0, 0))
 
 
 state = SharedState()

--- a/pyprland/common.py
+++ b/pyprland/common.py
@@ -182,8 +182,11 @@ def get_logger(name="pypr", level=None) -> logging.Logger:
     return logger
 
 
-class VersionInfo(tuple[int, int, int]):
-    pass
+@dataclass(order=True)
+class VersionInfo:
+    major: int = 0
+    minor: int = 0
+    micro: int = 0
 
 
 @dataclass
@@ -194,7 +197,7 @@ class SharedState:
     active_window: str = ""  # window address
     variables: dict = field(default_factory=dict)
     monitors: list[str] = field(default_factory=list)
-    hyprland_version: VersionInfo = VersionInfo((0, 0, 0))
+    hyprland_version: VersionInfo = field(default_factory=VersionInfo)
 
 
 state = SharedState()

--- a/pyprland/plugins/pyprland.py
+++ b/pyprland/plugins/pyprland.py
@@ -1,6 +1,6 @@
 " Not a real Plugin - provides some core features and some caching of commonly requested structures "
 from .interface import Plugin
-from ..common import state
+from ..common import state, VersionInfo
 
 
 class Extension(Plugin):
@@ -9,6 +9,13 @@ class Extension(Plugin):
     async def init(self):
         "initializes the plugin"
         state.active_window = ""
+        version = (await self.hyprctlJSON("version"))["tag"]
+        try:
+            state.hyprland_version = VersionInfo(
+                (int(i) for i in version[1:].split("."))
+            )
+        except Exception:
+            pass
         state.active_workspace = (await self.hyprctlJSON("activeworkspace"))["name"]
         monitors = await self.hyprctlJSON("monitors")
         state.monitors = [mon["name"] for mon in monitors]

--- a/pyprland/plugins/pyprland.py
+++ b/pyprland/plugins/pyprland.py
@@ -12,10 +12,11 @@ class Extension(Plugin):
         version = (await self.hyprctlJSON("version"))["tag"]
         try:
             state.hyprland_version = VersionInfo(
-                (int(i) for i in version[1:].split("."))
+                *(int(i) for i in version[1:].split(".")[:3])
             )
         except Exception:
-            pass
+            self.log.error("Fail to parse hyprctl version.")
+
         state.active_workspace = (await self.hyprctlJSON("activeworkspace"))["name"]
         monitors = await self.hyprctlJSON("monitors")
         state.monitors = [mon["name"] for mon in monitors]

--- a/pyprland/plugins/scratchpads/__init__.py
+++ b/pyprland/plugins/scratchpads/__init__.py
@@ -531,13 +531,15 @@ class Extension(CastBoolMixin, Plugin):  # pylint: disable=missing-class-docstri
     async def _show_transition(self, item, monitor, was_alive):
         "perfoms the transition to visible state"
         animation_type = item.conf.get("animation", "").lower()
-        wrkspc = monitor["activeWorkspace"]["name"]
+        wrkspc = monitor["specialWorkspace"]["name"]
+        if wrkspc == "":
+            wrkspc = monitor["activeWorkspace"]["name"]
         item.meta["last_shown"] = time.time()
         # Start the transition
         await self.hyprctl(
             [
                 f"moveworkspacetomonitor special:scratch_{item.uid} {monitor['name']}",
-                f"movetoworkspacesilent name:{wrkspc},address:{item.full_address}",
+                f"movetoworkspacesilent {wrkspc},address:{item.full_address}",
                 f"alterzorder top,address:{item.full_address}",
             ]
         )

--- a/pyprland/plugins/scratchpads/__init__.py
+++ b/pyprland/plugins/scratchpads/__init__.py
@@ -531,7 +531,7 @@ class Extension(CastBoolMixin, Plugin):  # pylint: disable=missing-class-docstri
     async def _show_transition(self, item, monitor, was_alive):
         "perfoms the transition to visible state"
         animation_type = item.conf.get("animation", "").lower()
-        close_special_workspace = item.conf.get("close_special_workspace")
+        close_special_workspace = item.conf.get("close_special_workspace", False)
         wrkspc = monitor["specialWorkspace"]["name"]
         if wrkspc == "" or close_special_workspace:
             wrkspc = monitor["activeWorkspace"]["name"]

--- a/pyprland/plugins/scratchpads/__init__.py
+++ b/pyprland/plugins/scratchpads/__init__.py
@@ -531,8 +531,9 @@ class Extension(CastBoolMixin, Plugin):  # pylint: disable=missing-class-docstri
     async def _show_transition(self, item, monitor, was_alive):
         "perfoms the transition to visible state"
         animation_type = item.conf.get("animation", "").lower()
+        close_special_workspace = item.conf.get("close_special_workspace")
         wrkspc = monitor["specialWorkspace"]["name"]
-        if wrkspc == "":
+        if wrkspc == "" or close_special_workspace:
             wrkspc = monitor["activeWorkspace"]["name"]
         item.meta["last_shown"] = time.time()
         # Start the transition

--- a/pyprland/plugins/scratchpads/objects.py
+++ b/pyprland/plugins/scratchpads/objects.py
@@ -11,7 +11,7 @@ from aiofiles import os as aios
 from aiofiles import open as aiopen
 
 from ...ipc import notify_error
-from ...common import CastBoolMixin
+from ...common import CastBoolMixin, state
 from .helpers import OverridableConfig, get_match_fn
 
 
@@ -39,6 +39,11 @@ class Scratch(CastBoolMixin):  # {{{
             opts["lazy"] = True
             if "match_by" not in opts:
                 opts["match_by"] = "class"
+        if state.hyprland_version < (0, 39, 0):
+            opts["close_special_workspace"] = True
+        elif opts.get("close_special_workspace", None) is None:
+            opts["close_special_workspace"] = False
+
         self.conf = opts
 
     async def initialize(self, ex):

--- a/pyprland/plugins/scratchpads/objects.py
+++ b/pyprland/plugins/scratchpads/objects.py
@@ -11,7 +11,7 @@ from aiofiles import os as aios
 from aiofiles import open as aiopen
 
 from ...ipc import notify_error
-from ...common import CastBoolMixin, state
+from ...common import CastBoolMixin, VersionInfo, state
 from .helpers import OverridableConfig, get_match_fn
 
 
@@ -39,10 +39,8 @@ class Scratch(CastBoolMixin):  # {{{
             opts["lazy"] = True
             if "match_by" not in opts:
                 opts["match_by"] = "class"
-        if state.hyprland_version < (0, 39, 0):
+        if state.hyprland_version < VersionInfo(0, 39, 0):
             opts["close_special_workspace"] = True
-        elif opts.get("close_special_workspace", None) is None:
-            opts["close_special_workspace"] = False
 
         self.conf = opts
 


### PR DESCRIPTION
Hi. 
Currently toggling scratchpads will close the opening special workspace. I think it's unexpected? 
And this feature need Hyprland version >= 0.39.0 due to:
- https://github.com/hyprwm/Hyprland/issues/4803

Maybe need to add an extra parameter in config file for compatibility.