### PR TITLE
fix special workspaces bug on expose.py

### DIFF
--- a/pyprland/plugins/expose.py
+++ b/pyprland/plugins/expose.py
@@ -23,7 +23,10 @@ class Extension(CastBoolMixin, Plugin):  # pylint: disable=missing-class-docstri
         If expose is active restores everything and move to the focused window
         """
         if self.exposed:
-            commands = [f"movetoworkspacesilent {client['workspace']['id']},address:{client['address']}" for client in self.exposed_clients]
+            commands = [
+                f"movetoworkspacesilent {client['workspace']['name']},address:{client['address']}"
+                for client in self.exposed_clients
+            ]
             commands.extend(
                 (
                     "togglespecialworkspace exposed",
@@ -36,6 +39,8 @@ class Extension(CastBoolMixin, Plugin):  # pylint: disable=missing-class-docstri
             self.exposed = await self.get_clients(workspace_bl=state.active_workspace)
             commands = []
             for client in self.exposed_clients:
-                commands.append(f"movetoworkspacesilent special:exposed,address:{client['address']}")
+                commands.append(
+                    f"movetoworkspacesilent special:exposed,address:{client['address']}"
+                )
             commands.append("togglespecialworkspace exposed")
             await self.hyprctl(commands)

--- a/pyprland/plugins/expose.py
+++ b/pyprland/plugins/expose.py
@@ -24,8 +24,7 @@ class Extension(CastBoolMixin, Plugin):  # pylint: disable=missing-class-docstri
         """
         if self.exposed:
             commands = [
-                f"movetoworkspacesilent {client['workspace']['name']},address:{client['address']}"
-                for client in self.exposed_clients
+                f"movetoworkspacesilent {client['workspace']['name']},address:{client['address']}" for client in self.exposed_clients
             ]
             commands.extend(
                 (
@@ -39,8 +38,6 @@ class Extension(CastBoolMixin, Plugin):  # pylint: disable=missing-class-docstri
             self.exposed = await self.get_clients(workspace_bl=state.active_workspace)
             commands = []
             for client in self.exposed_clients:
-                commands.append(
-                    f"movetoworkspacesilent special:exposed,address:{client['address']}"
-                )
+                commands.append(f"movetoworkspacesilent special:exposed,address:{client['address']}")
             commands.append("togglespecialworkspace exposed")
             await self.hyprctl(commands)

--- a/pyprland/plugins/scratchpads/__init__.py
+++ b/pyprland/plugins/scratchpads/__init__.py
@@ -760,7 +760,7 @@ class Extension(CastBoolMixin, Plugin):  # pylint: disable=missing-class-docstri
         if tracker and not tracker.prev_focused_window_wrkspc.startswith("special:"):
             same_workspace = tracker.prev_focused_window_wrkspc == active_workspace
             if scratch.have_address(active_window) and same_workspace and not scratch.have_address(tracker.prev_focused_window):
-                await self.run_show(scratch.uid)
+                await self.hyprctl(f"focuswindow address:{tracker.prev_focused_window}")
 
     # }}}
 

--- a/pyprland/plugins/scratchpads/__init__.py
+++ b/pyprland/plugins/scratchpads/__init__.py
@@ -760,7 +760,7 @@ class Extension(CastBoolMixin, Plugin):  # pylint: disable=missing-class-docstri
         if tracker and not tracker.prev_focused_window_wrkspc.startswith("special:"):
             same_workspace = tracker.prev_focused_window_wrkspc == active_workspace
             if scratch.have_address(active_window) and same_workspace and not scratch.have_address(tracker.prev_focused_window):
-                await self.show(scratch.uid)
+                await self.run_show(scratch.uid)
 
     # }}}
 

--- a/pyprland/plugins/scratchpads/__init__.py
+++ b/pyprland/plugins/scratchpads/__init__.py
@@ -760,7 +760,7 @@ class Extension(CastBoolMixin, Plugin):  # pylint: disable=missing-class-docstri
         if tracker and not tracker.prev_focused_window_wrkspc.startswith("special:"):
             same_workspace = tracker.prev_focused_window_wrkspc == active_workspace
             if scratch.have_address(active_window) and same_workspace and not scratch.have_address(tracker.prev_focused_window):
-                await self.hyprctl(f"focuswindow address:{tracker.prev_focused_window}")
+                await self.show(scratch.uid)
 
     # }}}
 


### PR DESCRIPTION
#119 
The solution was to use the name of the workspace instead of the id.
The id of special workspaces are negative, and using a negative workspace for `moveworkspacesilent` does not work.
Since the name the workspace returns the id (if it is normal) or the  name (if it is a special workspace), using name is more desirable.