### PR TITLE
Fix `NoneType object is not subscriptable` error in scratchpad's smart focus

### DIFF
--- a/pyprland/plugins/expose.py
+++ b/pyprland/plugins/expose.py
@@ -23,7 +23,10 @@ class Extension(CastBoolMixin, Plugin):  # pylint: disable=missing-class-docstri
         If expose is active restores everything and move to the focused window
         """
         if self.exposed:
-            commands = [f"movetoworkspacesilent {client['workspace']['id']},address:{client['address']}" for client in self.exposed_clients]
+            commands = [
+                f"movetoworkspacesilent {client['workspace']['name']},address:{client['address']}"
+                for client in self.exposed_clients
+            ]
             commands.extend(
                 (
                     "togglespecialworkspace exposed",
@@ -36,6 +39,8 @@ class Extension(CastBoolMixin, Plugin):  # pylint: disable=missing-class-docstri
             self.exposed = await self.get_clients(workspace_bl=state.active_workspace)
             commands = []
             for client in self.exposed_clients:
-                commands.append(f"movetoworkspacesilent special:exposed,address:{client['address']}")
+                commands.append(
+                    f"movetoworkspacesilent special:exposed,address:{client['address']}"
+                )
             commands.append("togglespecialworkspace exposed")
             await self.hyprctl(commands)

--- a/pyprland/plugins/expose.py
+++ b/pyprland/plugins/expose.py
@@ -23,9 +23,7 @@ class Extension(CastBoolMixin, Plugin):  # pylint: disable=missing-class-docstri
         If expose is active restores everything and move to the focused window
         """
         if self.exposed:
-            commands = [
-                f"movetoworkspacesilent {client['workspace']['name']},address:{client['address']}" for client in self.exposed_clients
-            ]
+            commands = [f"movetoworkspacesilent {client['workspace']['id']},address:{client['address']}" for client in self.exposed_clients]
             commands.extend(
                 (
                     "togglespecialworkspace exposed",

--- a/pyprland/plugins/expose.py
+++ b/pyprland/plugins/expose.py
@@ -24,8 +24,7 @@ class Extension(CastBoolMixin, Plugin):  # pylint: disable=missing-class-docstri
         """
         if self.exposed:
             commands = [
-                f"movetoworkspacesilent {client['workspace']['name']},address:{client['address']}"
-                for client in self.exposed_clients
+                f"movetoworkspacesilent {client['workspace']['name']},address:{client['address']}" for client in self.exposed_clients
             ]
             commands.extend(
                 (
@@ -39,8 +38,6 @@ class Extension(CastBoolMixin, Plugin):  # pylint: disable=missing-class-docstri
             self.exposed = await self.get_clients(workspace_bl=state.active_workspace)
             commands = []
             for client in self.exposed_clients:
-                commands.append(
-                    f"movetoworkspacesilent special:exposed,address:{client['address']}"
-                )
+                commands.append(f"movetoworkspacesilent special:exposed,address:{client['address']}")
             commands.append("togglespecialworkspace exposed")
             await self.hyprctl(commands)

--- a/pyprland/plugins/scratchpads/__init__.py
+++ b/pyprland/plugins/scratchpads/__init__.py
@@ -760,12 +760,12 @@ class Extension(CastBoolMixin, Plugin):  # pylint: disable=missing-class-docstri
         if tracker and not tracker.prev_focused_window_wrkspc.startswith("special:"):
             same_workspace = tracker.prev_focused_window_wrkspc == active_workspace
             clients = await self.hyprctl_json("clients")
-            client = next(filter(lambda d: d.get("address") == tracker.prev_focused_window, clients), None)
+            client = next(filter(lambda d: d.get("address") == tracker.prev_focused_window, clients), {})
             if (
                 scratch.have_address(active_window)
                 and same_workspace
                 and not scratch.have_address(tracker.prev_focused_window)
-                and not client["workspace"]["name"].startswith("special")
+                and not client.get("workspace", {}).get("name", "").startswith("special")
             ):
                 await self.hyprctl(f"focuswindow address:{tracker.prev_focused_window}")
 

--- a/pyprland/plugins/scratchpads/__init__.py
+++ b/pyprland/plugins/scratchpads/__init__.py
@@ -759,7 +759,14 @@ class Extension(CastBoolMixin, Plugin):  # pylint: disable=missing-class-docstri
         tracker = self.focused_window_tracking.get(scratch.uid)
         if tracker and not tracker.prev_focused_window_wrkspc.startswith("special:"):
             same_workspace = tracker.prev_focused_window_wrkspc == active_workspace
-            if scratch.have_address(active_window) and same_workspace and not scratch.have_address(tracker.prev_focused_window):
+            clients = await self.hyprctl_json("clients")
+            client = next(filter(lambda d: d.get("address") == tracker.prev_focused_window, clients), None)
+            if (
+                scratch.have_address(active_window)
+                and same_workspace
+                and not scratch.have_address(tracker.prev_focused_window)
+                and not client["workspace"]["name"].startswith("special")
+            ):
                 await self.hyprctl(f"focuswindow address:{tracker.prev_focused_window}")
 
     # }}}


### PR DESCRIPTION
The current code could try to subscript on `None`, which would cause `NoneType object is not subscriptable` error.
The fix was to change the default from `None` to an empty dict, then use `get` with default values to stop errors.