### PR TITLE
Add the excludes_stash feature for scratchpads

### DIFF
--- a/pyprland/plugins/scratchpads/objects.py
+++ b/pyprland/plugins/scratchpads/objects.py
@@ -48,6 +48,7 @@ class Scratch(CastBoolMixin):  # {{{
     uid = ""
     monitor = ""
     pid = -1
+    excluded_scratches = []
 
     def __init__(self, uid: str, opts: dict[str, Any]) -> None:
         self.uid = uid


### PR DESCRIPTION
The feature is described in issue #123 :
    After a scratch that excludes windows is hidden, any scratches it made hide return to the screen.

Implementation:
```
Add excluded_scratches property to the Scratch class.
If excludes_stash is set true in config, put excluded scratches in excluded_scratches property.
When this scratchpad is closed, the scratches in excluded_scratches are shown.
```