### PR TITLE
Add close_on_hide option to scratchpads

### DIFF
--- a/pyprland/plugins/scratchpads/__init__.py
+++ b/pyprland/plugins/scratchpads/__init__.py
@@ -792,6 +792,9 @@ class Extension(CastBoolMixin, Plugin):  # pylint: disable=missing-class-docstri
             self.log.warning("%s is not configured", uid)
             return
 
+        if not await scratch.is_alive():
+            return
+
         if flavor & HideFlavors.IGNORE_TILED and not scratch.client_info["floating"]:
             return
 

--- a/pyprland/plugins/scratchpads/__init__.py
+++ b/pyprland/plugins/scratchpads/__init__.py
@@ -825,11 +825,18 @@ class Extension(CastBoolMixin, Plugin):  # pylint: disable=missing-class-docstri
         await self._pin_scratch(scratch)
         await self._hide_transition(scratch, monitor_info)
 
-        await self.hyprctl(f"movetoworkspacesilent special:scratch_{uid},address:{scratch.full_address}")
+        if not self.cast_bool(scratch.conf.get("close_on_hide"), False):
+            await self.hyprctl(f"movetoworkspacesilent special:scratch_{uid},address:{scratch.full_address}")
 
-        for addr in scratch.extra_addr:
-            await self.hyprctl(f"movetoworkspacesilent special:scratch_{uid},address:{addr}")
-            await asyncio.sleep(0.01)
+            for addr in scratch.extra_addr:
+                await self.hyprctl(f"movetoworkspacesilent special:scratch_{uid},address:{addr}")
+                await asyncio.sleep(0.01)
+        else:
+            await self.hyprctl(f"closewindow address:{scratch.full_address}")
+
+            for addr in scratch.extra_addr:
+                await self.hyprctl(f"closewindow address:{addr}")
+                await asyncio.sleep(0.01)
 
         for e_uid in scratch.excluded_scratches:
             await self.run_show(e_uid)

--- a/pyprland/plugins/scratchpads/objects.py
+++ b/pyprland/plugins/scratchpads/objects.py
@@ -99,6 +99,8 @@ class Scratch(CastBoolMixin):  # {{{
             opts["lazy"] = True
             if "match_by" not in opts:
                 opts["match_by"] = "class"
+        if opts.get("close_on_hide", False):
+            opts["lazy"] = True
         if state.hyprland_version < VersionInfo(0, 39, 0):
             opts["allow_special_workspace"] = False
 

--- a/site/scratchpads_advanced.md
+++ b/site/scratchpads_advanced.md
@@ -160,5 +160,5 @@ When enabled, the window in the scratchpad is closed instead of hidden when `pyp
 This option implies `lazy = true`.
 This can be useful on laptops where background apps may increase battery power draw.
 
-Note: Currently this option changed the hide animation to use hyprland's close window animation.
+Note: Currently this option changes the hide animation to use hyprland's close window animation.
 

--- a/site/scratchpads_advanced.md
+++ b/site/scratchpads_advanced.md
@@ -152,3 +152,13 @@ Default value is `true`.
 When enabled, the focus will be restored in a best effort way as en attempt to improve the user experience.
 If you face issues such as spontaneous workspace changes, you can disable this feature.
 
+## `close_on_hide`
+
+Default value is `false`.
+
+When enabled, the window in the scratchpad is closed instead of hidden when `pypr hide <name>` is run.
+This option implies `lazy = true`.
+This can be useful on laptops where background apps may increase battery power draw.
+
+Note: Currently this option changed the hide animation to use hyprland's close window animation.
+


### PR DESCRIPTION
#175

This implements a scratchpad config option to close the window when the hide command in run and adds a check in run_hide to silently skip hiding windows that have died. I also added some docs for my changes.