### PR TITLE
fix(shift_monitors): grimblastVD monitor removed error

### DIFF
--- a/pyprland/plugins/shift_monitors.py
+++ b/pyprland/plugins/shift_monitors.py
@@ -29,6 +29,6 @@ class Extension(Plugin):  # pylint: disable=missing-class-docstring
     async def event_monitorremoved(self, monitor: str) -> None:
         """Keep track of monitors."""
         try:
-            state.monitors.remove(name)
+            self.monitors.remove(monitor)
         except ValueError:
-            self.log.warning("Monitor %s not found in state - can't be removed", name)
+            self.log.warning("Monitor %s not found in state - can't be removed", monitor)


### PR DESCRIPTION
Resolves #161 in the same way as a519b80, but for the `shift_monitors` plugin