### PR TITLE
fix(scratchpads): anchor hide animation to configured position

### DIFF
--- a/pyprland/plugins/scratchpads/__init__.py
+++ b/pyprland/plugins/scratchpads/__init__.py
@@ -496,6 +496,12 @@ class Extension(LifecycleMixin, EventsMixin, TransitionsMixin, Plugin, environme
         if monitor_info is None:
             self.log.error("Cannot hide %s: no monitor_info available", scratch.uid)
             return
+
+        configured_position = scratch.conf.get_str("position")
+        if configured_position:
+            pos_x, pos_y = convert_coords(configured_position, monitor_info)
+            ref_position = (pos_x + monitor_info["x"], pos_y + monitor_info["y"])
+
         scratch.meta.extra_positions[scratch.address] = compute_offset(ref_position, (monitor_info["x"], monitor_info["y"]))
         # collects window which have been created by the app
         if scratch.conf.get_bool("multi"):


### PR DESCRIPTION
# Description of the pull request content & goal

Fixes #211.

When a scratchpad has an explicit `position`, hide animations should start from that configured anchor instead of the last runtime `client_info["at"]` coordinates. After a tile→float round-trip, `client_info["at"]` can drift, which causes `fromBottom`/slide hides to stop partially onscreen.

This change keeps the diff minimal by only adjusting `_hide_scratch`: if `position` is set, convert it to absolute monitor coordinates and use that as the animation reference; otherwise keep existing behavior.

Validation:
- `python -m compileall -q pyprland/plugins/scratchpads/__init__.py`
- Full test suite not run in this environment (`pytest` is not installed here).

# Relevant wiki content to be added/updated

## In "Scratchpads" docs

Clarify that when `position` is configured, hide animations are anchored to configured coordinates (not the last manually moved/tiled coordinates).
