### PR TITLE
Feature/matrix030 stash

### DIFF
--- a/pyprland/plugins/stash.py
+++ b/pyprland/plugins/stash.py
@@ -1,144 +1,286 @@
-"""stash allows stashing and showing windows in named groups."""
+"""stash allows storing named single-window overlays."""
 
-import asyncio
-from typing import cast
+from __future__ import annotations
 
+import logging
+from dataclasses import dataclass
+from typing import Any, cast
+
+from ..adapters.units import convert_coords
 from ..models import Environment, ReloadReason
-from ..validation import ConfigField, ConfigItems
+from ..validation import ConfigField, ConfigItems, ConfigValidator
 from .interface import Plugin
 
 STASH_PREFIX = "st-"
-STASH_TAG = "stashed"
+PAIR_SIZE = 2
+
+STASH_SECTION_SCHEMA = ConfigItems(
+    ConfigField("animation", str, default="", description="Reserved animation setting", category="basic"),
+    ConfigField("size", str, required=True, description="Overlay size like '24% 54%'", category="positioning"),
+    ConfigField("position", str, required=True, description="Overlay position like '76% 22%'", category="positioning"),
+    ConfigField("preserve_aspect", bool, default=False, description="Keep size and position across shows", category="behavior"),
+)
+
+
+@dataclass
+class StashDefinition:
+    """User-defined stash properties."""
+
+    name: str
+    animation: str
+    size: str
+    position: str
+    preserve_aspect: bool
+
+
+@dataclass
+class StashSlot:
+    """Runtime state for a single stash."""
+
+    definition: StashDefinition
+    address: str = ""
+    was_floating: bool = True
+    visible: bool = False
+    saved_size: tuple[int, int] | None = None
+    saved_offset: tuple[int, int] | None = None
+
+    @property
+    def workspace(self) -> str:
+        """Return the hidden workspace backing this stash."""
+        return f"special:{STASH_PREFIX}{self.definition.name}"
+
+    @property
+    def occupied(self) -> bool:
+        """Return whether this stash currently owns a window."""
+        return bool(self.address)
 
 
 class Extension(Plugin, environments=[Environment.HYPRLAND]):
-    """Stash and show windows in named groups using special workspaces."""
-
-    config_schema = ConfigItems(
-        ConfigField("style", list, default=[], description="Window rules to apply to shown stash windows", category="basic"),
-    )
+    """Manage named single-window stashes as pinned overlays."""
 
     def __init__(self, name: str) -> None:
         super().__init__(name)
-        self._visible: dict[str, bool] = {}
-        self._shown_addresses: dict[str, list[str]] = {}
-        self._was_floating: dict[str, bool] = {}
+        self._slots: dict[str, StashSlot] = {}
+        self._addr_to_stash: dict[str, str] = {}
+
+    def validate_config(self) -> list[str]:
+        """Validate nested stash sections."""
+        return self._validate_stash_config(self.name, dict(self.config))
+
+    @classmethod
+    def validate_config_static(cls, plugin_name: str, config: dict) -> list[str]:
+        """Validate nested stash sections without instantiating the plugin."""
+        return cls._validate_stash_config(plugin_name, config)
+
+    @classmethod
+    def _validate_stash_config(cls, plugin_name: str, config: dict) -> list[str]:
+        log_name = f"pyprland.plugins.{plugin_name}"
+        validator = ConfigValidator(config, plugin_name, logging.getLogger(log_name))
+        errors: list[str] = []
+        for stash_name, stash_config in config.items():
+            if not isinstance(stash_config, dict):
+                errors.append(f"[{plugin_name}] section '{stash_name}' must be a table")
+                continue
+            child_prefix = f"{plugin_name}.{stash_name}"
+            child_validator = ConfigValidator(stash_config, child_prefix, validator.log)
+            errors.extend(child_validator.validate(STASH_SECTION_SCHEMA))
+            errors.extend(child_validator.warn_unknown_keys(STASH_SECTION_SCHEMA))
+        return errors
 
     async def on_reload(self, reason: ReloadReason = ReloadReason.RELOAD) -> None:  # noqa: ARG002
-        """Clear old tag rules and re-register window rules for stash styling."""
-        await self.backend.execute(
-            f"windowrule tag -{STASH_TAG}",
-            base_command="keyword",
-        )
-        style = self.get_config_list("style")
-        if style:
-            commands = [f"windowrule {rule}, match:tag {STASH_TAG}" for rule in style]
-            await self.backend.execute(commands, base_command="keyword")
+        """Refresh configured stash definitions."""
+        self._load_stash_definitions()
 
-    async def run_stash(self, name: str = "default") -> None:
-        """[name] Toggle stashing the focused window (default stash: "default").
+    async def exit(self) -> None:
+        """Best-effort release of stashed windows during clean shutdown."""
+        for slot in self._slots.values():
+            if slot.occupied:
+                await self._release_slot(slot, workspace=self.state.active_workspace, focus=False)
 
-        Args:
-            name: The stash group name
-        """
-        aw = cast("dict", await self.backend.execute_json("activewindow"))
-        addr = aw.get("address", "")
+    async def event_closewindow(self, addr: str) -> None:
+        """Remove closed windows from stash tracking."""
+        address = "0x" + addr
+        stash_name = self._addr_to_stash.pop(address, "")
+        if not stash_name:
+            return
+        slot = self._slots.get(stash_name)
+        if slot is None or slot.address != address:
+            return
+        self._clear_slot(slot)
+
+    async def run_stash_send(self, name: str) -> None:
+        """<name> Send the focused window to stash <name>, or release it if already focused there."""
+        slot = self._require_slot(name)
+        active = await self._get_active_window()
+        addr = active.get("address", "")
         if not addr:
             return
 
-        # If the window was shown via stash_toggle, just remove it from tracking
-        for group, addresses in self._shown_addresses.items():
-            if addr in addresses:
-                addresses.remove(addr)
-                await self._restore_floating(addr)
-                if not addresses:
-                    self._shown_addresses.pop(group)
-                    self._visible[group] = False
-                return
-
-        ws_name = aw["workspace"]["name"]
-        await asyncio.sleep(0.1)
-
-        if ws_name.startswith(f"special:{STASH_PREFIX}"):
-            # Window is stashed → unstash it to current workspace
-            await self.backend.move_window_to_workspace(addr, self.state.active_workspace, silent=True)
-            await self.backend.focus_window(addr)
-
-            await asyncio.sleep(0.1)
-            await self._restore_floating(addr)
-        else:
-            # Window is not stashed → stash it
-            was_floating = aw.get("floating", False)
-            self._was_floating[addr] = was_floating
-            await self.backend.move_window_to_workspace(addr, f"special:{STASH_PREFIX}{name}", silent=True)
-            await asyncio.sleep(0.1)
-            if not was_floating:
-                await self.backend.toggle_floating(addr)
-            await asyncio.sleep(0.1)
-            if self.get_config_list("style"):
-                await self.backend.execute(f"tagwindow +{STASH_TAG} address:{addr}")
-
-    async def _restore_floating(self, addr: str) -> None:
-        """Restore a window's original floating state and remove stash tag."""
-        if not self._was_floating.pop(addr, True):
-            await self.backend.toggle_floating(addr)
-            await asyncio.sleep(0.1)
-        if self.get_config_list("style"):
-            await self.backend.execute(f"tagwindow -{STASH_TAG} address:{addr}")
-
-    async def event_closewindow(self, addr: str) -> None:
-        """Remove a closed window from stash tracking.
-
-        Args:
-            addr: Window address as hex string (without 0x prefix)
-        """
-        addr = "0x" + addr
-        self._was_floating.pop(addr, None)
-        for group in list(self._shown_addresses):
-            addresses = self._shown_addresses[group]
-            if addr in addresses:
-                addresses.remove(addr)
-                if not addresses:
-                    del self._shown_addresses[group]
-                    self._visible[group] = False
-
-    async def run_stash_toggle(self, name: str = "default") -> None:
-        """[name] Show or hide stash "name" as floating windows on the active workspace (default: "default").
-
-        When showing, windows are moved from the hidden stash workspace to the
-        active workspace and made floating.  When hiding, they are moved back.
-
-        Args:
-            name: The stash group name
-        """
-        if self._visible.get(name, False):
-            await self._hide_stash(name)
-        else:
-            await self._show_stash(name)
-
-    async def _show_stash(self, name: str) -> None:
-        """Move stashed windows to the active workspace."""
-        stash_ws = f"special:{STASH_PREFIX}{name}"
-        clients = await self.get_clients(workspace=stash_ws)
-        if not clients:
+        current_stash = self._addr_to_stash.get(addr)
+        if current_stash == name:
+            await self._release_slot(slot, workspace=self.state.active_workspace)
             return
 
-        addresses: list[str] = []
-        for client in clients:
-            addr = client["address"]
-            addresses.append(addr)
-            await self.backend.move_window_to_workspace(addr, self.state.active_workspace, silent=True)
+        if current_stash:
+            await self._detach_from_stash(self._slots[current_stash], keep_floating=True)
 
-        self._shown_addresses[name] = addresses
-        self._visible[name] = True
+        if slot.occupied:
+            await self._release_slot(slot, workspace=self.state.active_workspace, focus=False)
 
-    async def _hide_stash(self, name: str) -> None:
-        """Move previously shown stash windows back to the hidden workspace."""
-        stash_ws = f"special:{STASH_PREFIX}{name}"
-        addresses = self._shown_addresses.get(name, [])
+        await self._stash_window(slot, active)
 
-        for addr in addresses:
-            await self.backend.move_window_to_workspace(addr, stash_ws)
+    async def run_stash_toggle(self, name: str) -> None:
+        """<name> Show or hide the named stash overlay."""
+        slot = self._require_slot(name)
+        if not slot.occupied:
+            return
+        if slot.visible:
+            await self._hide_slot(slot)
+        else:
+            await self._show_slot(slot)
 
-        self._shown_addresses.pop(name, None)
-        self._visible[name] = False
+    def _load_stash_definitions(self) -> None:
+        previous = self._slots
+        self._slots = {}
+
+        for stash_name, stash_config in self.config.iter_subsections():
+            slot = previous.get(stash_name)
+            definition = StashDefinition(
+                name=stash_name,
+                animation=str(stash_config.get("animation", "")),
+                size=str(stash_config["size"]),
+                position=str(stash_config["position"]),
+                preserve_aspect=bool(stash_config.get("preserve_aspect", False)),
+            )
+            if slot is None:
+                slot = StashSlot(definition=definition)
+            else:
+                slot.definition = definition
+            self._slots[stash_name] = slot
+
+    def _require_slot(self, name: str) -> StashSlot:
+        if name not in self._slots:
+            self._load_stash_definitions()
+        try:
+            return self._slots[name]
+        except KeyError as e:
+            msg = f"Unknown stash '{name}'"
+            raise ValueError(msg) from e
+
+    async def _get_active_window(self) -> dict[str, Any]:
+        return cast("dict[str, Any]", await self.backend.execute_json("activewindow"))
+
+    async def _stash_window(self, slot: StashSlot, active: dict[str, Any]) -> None:
+        addr = cast("str", active["address"])
+        slot.address = addr
+        slot.was_floating = bool(active.get("floating", False))
+        slot.visible = False
+        self._addr_to_stash[addr] = slot.definition.name
+
+        await self.backend.move_window_to_workspace(addr, slot.workspace, silent=True)
+        if not slot.was_floating:
+            await self.backend.toggle_floating(addr)
+
+    async def _show_slot(self, slot: StashSlot) -> None:
+        if not slot.occupied:
+            return
+
+        await self.backend.move_window_to_workspace(slot.address, self.state.active_workspace, silent=True)
+        await self._apply_geometry(slot)
+        await self.backend.pin_window(slot.address)
+        await self.backend.focus_window(slot.address)
+        slot.visible = True
+
+    async def _hide_slot(self, slot: StashSlot) -> None:
+        if not slot.occupied:
+            return
+
+        await self._capture_geometry(slot)
+        if slot.visible:
+            await self.backend.pin_window(slot.address)
+        await self.backend.move_window_to_workspace(slot.address, slot.workspace, silent=True)
+        slot.visible = False
+
+    async def _release_slot(self, slot: StashSlot, workspace: str, *, focus: bool = True) -> None:
+        if not slot.occupied:
+            return
+
+        addr = slot.address
+        if slot.visible:
+            await self.backend.pin_window(addr)
+        await self.backend.move_window_to_workspace(addr, workspace, silent=True)
+        await self._restore_floating(slot)
+        if focus:
+            await self.backend.focus_window(addr)
+        self._clear_slot(slot)
+
+    async def _detach_from_stash(self, slot: StashSlot, *, keep_floating: bool) -> None:
+        if not slot.occupied:
+            return
+
+        if slot.visible:
+            await self.backend.pin_window(slot.address)
+        if not keep_floating:
+            await self._restore_floating(slot)
+        self._clear_slot(slot)
+
+    async def _restore_floating(self, slot: StashSlot) -> None:
+        if slot.was_floating:
+            return
+        await self.backend.toggle_floating(slot.address)
+
+    def _clear_slot(self, slot: StashSlot) -> None:
+        if slot.address:
+            self._addr_to_stash.pop(slot.address, None)
+        slot.address = ""
+        slot.visible = False
+        slot.was_floating = True
+        slot.saved_size = None
+        slot.saved_offset = None
+
+    async def _capture_geometry(self, slot: StashSlot) -> None:
+        if not slot.definition.preserve_aspect:
+            return
+
+        client = await self.backend.get_client_props(addr=slot.address)
+        if client is None:
+            return
+
+        size = client.get("size")
+        position = client.get("at")
+        if not isinstance(size, (list, tuple)) or len(size) != PAIR_SIZE:
+            return
+        if not isinstance(position, (list, tuple)) or len(position) != PAIR_SIZE:
+            return
+
+        slot.saved_size = (int(size[0]), int(size[1]))
+
+        monitor = await self.get_focused_monitor_or_warn("stash geometry save")
+        if monitor is None:
+            slot.saved_offset = (int(position[0]), int(position[1]))
+            return
+
+        base_x = int(monitor["x"] / monitor["scale"])
+        base_y = int(monitor["y"] / monitor["scale"])
+        slot.saved_offset = (int(position[0]) - base_x, int(position[1]) - base_y)
+
+    async def _apply_geometry(self, slot: StashSlot) -> None:
+        monitor = await self.get_focused_monitor_or_warn("stash geometry")
+        if monitor is None:
+            return
+
+        base_x = int(monitor["x"] / monitor["scale"])
+        base_y = int(monitor["y"] / monitor["scale"])
+
+        if slot.definition.preserve_aspect and slot.saved_size and slot.saved_offset:
+            width, height = slot.saved_size
+            x = base_x + slot.saved_offset[0]
+            y = base_y + slot.saved_offset[1]
+        else:
+            width, height = convert_coords(slot.definition.size, monitor)
+            x, y = convert_coords(slot.definition.position, monitor)
+            x += base_x
+            y += base_y
+
+        await self.backend.resize_window(slot.address, width, height)
+        await self.backend.move_window(slot.address, x, y)

--- a/pyprland/plugins/stash.py
+++ b/pyprland/plugins/stash.py
@@ -89,7 +89,11 @@ class Extension(Plugin, environments=[Environment.HYPRLAND]):
 
     async def on_reload(self, reason: ReloadReason = ReloadReason.RELOAD) -> None:  # noqa: ARG002
         """Refresh configured stash definitions."""
+        previous_slots = self._slots
         self._load_stash_definitions()
+        for stash_name, slot in previous_slots.items():
+            if stash_name not in self._slots and slot.occupied:
+                await self._release_slot(slot, workspace=self.state.active_workspace, focus=False)
 
     async def exit(self) -> None:
         """Best-effort release of stashed windows during clean shutdown."""
@@ -121,13 +125,19 @@ class Extension(Plugin, environments=[Environment.HYPRLAND]):
             await self._release_slot(slot, workspace=self.state.active_workspace)
             return
 
+        original_was_floating: bool | None = None
         if current_stash:
-            await self._detach_from_stash(self._slots[current_stash], keep_floating=True)
+            current_slot = self._slots.get(current_stash)
+            if current_slot is not None:
+                original_was_floating = current_slot.was_floating
+                await self._detach_from_stash(current_slot, keep_floating=True)
+            else:
+                self._addr_to_stash.pop(addr, None)
 
         if slot.occupied:
             await self._release_slot(slot, workspace=self.state.active_workspace, focus=False)
 
-        await self._stash_window(slot, active)
+        await self._stash_window(slot, active, was_floating=original_was_floating)
 
     async def run_stash_toggle(self, name: str) -> None:
         """<name> Show or hide the named stash overlay."""
@@ -170,15 +180,16 @@ class Extension(Plugin, environments=[Environment.HYPRLAND]):
     async def _get_active_window(self) -> dict[str, Any]:
         return cast("dict[str, Any]", await self.backend.execute_json("activewindow"))
 
-    async def _stash_window(self, slot: StashSlot, active: dict[str, Any]) -> None:
+    async def _stash_window(self, slot: StashSlot, active: dict[str, Any], *, was_floating: bool | None = None) -> None:
         addr = cast("str", active["address"])
+        is_currently_floating = bool(active.get("floating", False))
         slot.address = addr
-        slot.was_floating = bool(active.get("floating", False))
+        slot.was_floating = is_currently_floating if was_floating is None else was_floating
         slot.visible = False
         self._addr_to_stash[addr] = slot.definition.name
 
         await self.backend.move_window_to_workspace(addr, slot.workspace, silent=True)
-        if not slot.was_floating:
+        if not is_currently_floating:
             await self.backend.toggle_floating(addr)
 
     async def _show_slot(self, slot: StashSlot) -> None:
@@ -260,8 +271,8 @@ class Extension(Plugin, environments=[Environment.HYPRLAND]):
             slot.saved_offset = (int(position[0]), int(position[1]))
             return
 
-        base_x = int(monitor["x"] / monitor["scale"])
-        base_y = int(monitor["y"] / monitor["scale"])
+        base_x = int(monitor["x"])
+        base_y = int(monitor["y"])
         slot.saved_offset = (int(position[0]) - base_x, int(position[1]) - base_y)
 
     async def _apply_geometry(self, slot: StashSlot) -> None:
@@ -269,8 +280,8 @@ class Extension(Plugin, environments=[Environment.HYPRLAND]):
         if monitor is None:
             return
 
-        base_x = int(monitor["x"] / monitor["scale"])
-        base_y = int(monitor["y"] / monitor["scale"])
+        base_x = int(monitor["x"])
+        base_y = int(monitor["y"])
 
         if slot.definition.preserve_aspect and slot.saved_size and slot.saved_offset:
             width, height = slot.saved_size

--- a/site/stash.md
+++ b/site/stash.md
@@ -3,25 +3,31 @@
 
 # stash
 
-Stash and show windows in named groups using special workspaces.
+Store single-window overlays in named stashes.
 
-Unlike `toggle_special` which uses a single special workspace, `stash` supports multiple named stash groups. Windows can be quickly stashed away and retrieved later, appearing on whichever workspace you are currently on.
+Each stash name is a single slot. A stashed window can be shown as a pinned overlay on top of your current workspace and stays visible while you switch workspaces, including special workspaces.
 
 ## Usage
 
 ```bash
-bind = $mainMod, S, exec, pypr stash          # toggle stash the focused window
-bind = $mainMod SHIFT, S, exec, pypr stash_toggle # show/hide stashed windows
+bind = $mainMod,       S, exec, pypr stash_toggle S
+bind = $mainMod SHIFT, S, exec, pypr stash_send   S
+bind = $mainMod,       C, exec, pypr stash_toggle C
+bind = $mainMod SHIFT, C, exec, pypr stash_send   C
 ```
 
-For multiple stash groups:
+`stash_send <name>`:
 
-```bash
-bind = $mainMod, S, exec, pypr stash default
-bind = $mainMod, W, exec, pypr stash work
-bind = $mainMod SHIFT, S, exec, pypr stash_toggle default
-bind = $mainMod SHIFT, W, exec, pypr stash_toggle work
-```
+- sends the focused window into stash `<name>`
+- if `<name>` is already occupied, releases the old window to the current workspace and replaces it
+- if the focused window is already the shown stash window, releases it back to the current workspace
+
+`stash_toggle <name>`:
+
+- shows the named stash as a pinned floating overlay
+- hides it back into its hidden special workspace
+
+The first show uses the configured `size` and `position`. If `preserve_aspect = true`, later hide/show cycles keep the live size and position you last left the stash at.
 
 ## Commands
 
@@ -34,12 +40,24 @@ bind = $mainMod SHIFT, W, exec, pypr stash_toggle work
 ### Example
 
 ```toml
-[stash]
-style = [
-    "border_color rgb(ec8800)",
-    "border_size 3",
-]
+[pyprland]
+plugins = ["stash"]
+
+[stash.S]
+animation = ""
+size = "24% 54%"
+position = "76% 22%"
+preserve_aspect = true
+
+[stash.C]
+animation = ""
+size = "24% 54%"
+position = "76% 22%"
+preserve_aspect = true
 ```
 
-When `style` is set, shown stash windows are tagged with `stash` and the listed [window rules](https://wiki.hyprland.org/Configuring/Window-Rules/) are applied.
-The tag is removed when windows are hidden or removed from the stash.
+## Notes
+
+- `animation` is currently reserved and does not change behavior yet.
+- Stash windows are backed by hidden `special:st-<name>` workspaces when not shown.
+- During a clean `pypr` shutdown, stash windows are released back to the active workspace as a best effort cleanup.

--- a/site/versions/3.3.1/stash.md
+++ b/site/versions/3.3.1/stash.md
@@ -3,25 +3,31 @@
 
 # stash
 
-Stash and show windows in named groups using special workspaces.
+Store single-window overlays in named stashes.
 
-Unlike `toggle_special` which uses a single special workspace, `stash` supports multiple named stash groups. Windows can be quickly stashed away and retrieved later, appearing on whichever workspace you are currently on.
+Each stash name is a single slot. A stashed window can be shown as a pinned overlay on top of your current workspace and stays visible while you switch workspaces, including special workspaces.
 
 ## Usage
 
 ```bash
-bind = $mainMod, S, exec, pypr stash          # toggle stash the focused window
-bind = $mainMod SHIFT, S, exec, pypr stash_toggle # show/hide stashed windows
+bind = $mainMod,       S, exec, pypr stash_toggle S
+bind = $mainMod SHIFT, S, exec, pypr stash_send   S
+bind = $mainMod,       C, exec, pypr stash_toggle C
+bind = $mainMod SHIFT, C, exec, pypr stash_send   C
 ```
 
-For multiple stash groups:
+`stash_send <name>`:
 
-```bash
-bind = $mainMod, S, exec, pypr stash default
-bind = $mainMod, W, exec, pypr stash work
-bind = $mainMod SHIFT, S, exec, pypr stash_toggle default
-bind = $mainMod SHIFT, W, exec, pypr stash_toggle work
-```
+- sends the focused window into stash `<name>`
+- if `<name>` is already occupied, releases the old window to the current workspace and replaces it
+- if the focused window is already the shown stash window, releases it back to the current workspace
+
+`stash_toggle <name>`:
+
+- shows the named stash as a pinned floating overlay
+- hides it back into its hidden special workspace
+
+The first show uses the configured `size` and `position`. If `preserve_aspect = true`, later hide/show cycles keep the live size and position you last left the stash at.
 
 ## Commands
 
@@ -34,12 +40,24 @@ bind = $mainMod SHIFT, W, exec, pypr stash_toggle work
 ### Example
 
 ```toml
-[stash]
-style = [
-    "border_color rgb(ec8800)",
-    "border_size 3",
-]
+[pyprland]
+plugins = ["stash"]
+
+[stash.S]
+animation = ""
+size = "24% 54%"
+position = "76% 22%"
+preserve_aspect = true
+
+[stash.C]
+animation = ""
+size = "24% 54%"
+position = "76% 22%"
+preserve_aspect = true
 ```
 
-When `style` is set, shown stash windows are tagged with `stash` and the listed [window rules](https://wiki.hyprland.org/Configuring/Window-Rules/) are applied.
-The tag is removed when windows are hidden or removed from the stash.
+## Notes
+
+- `animation` is currently reserved and does not change behavior yet.
+- Stash windows are backed by hidden `special:st-<name>` workspaces when not shown.
+- During a clean `pypr` shutdown, stash windows are released back to the active workspace as a best effort cleanup.

--- a/tests/test_plugin_stash.py
+++ b/tests/test_plugin_stash.py
@@ -2,464 +2,238 @@ import pytest
 
 from pyprland.plugins.stash import Extension
 from tests.conftest import make_extension
-from tests.testtools import get_executed_commands
+
+
+CONFIG = {
+    "S": {
+        "animation": "",
+        "size": "24% 54%",
+        "position": "76% 22%",
+        "preserve_aspect": False,
+    },
+    "C": {
+        "animation": "",
+        "size": "24% 54%",
+        "position": "76% 22%",
+        "preserve_aspect": True,
+    },
+}
+
+MONITOR = {
+    "x": 10,
+    "y": 20,
+    "width": 1000,
+    "height": 800,
+    "scale": 1.0,
+    "transform": 0,
+}
 
 
 @pytest.fixture
 def extension():
-    return make_extension(Extension)
-
-
-@pytest.fixture
-def styled_extension():
-    return make_extension(Extension, config={"style": ["border_color rgb(ec8800)", "border_size 3"]})
-
-
-# -- run_stash: stashing --
+    ext = make_extension(Extension, config=CONFIG)
+    ext.backend.get_monitor_props.return_value = MONITOR
+    ext.backend.get_client_props.return_value = {"size": [600, 400], "at": [770, 196]}
+    return ext
 
 
 @pytest.mark.asyncio
-async def test_stash_moves_window_to_special_workspace(extension):
-    """Stashing a tiled window moves it to special:st-default and makes it floating."""
+async def test_stash_send_moves_window_to_named_special_workspace(extension):
     extension.backend.execute_json.return_value = {
         "address": "0xabc",
         "floating": False,
         "workspace": {"id": 1, "name": "1"},
     }
 
-    await extension.run_stash()
+    await extension.run_stash_send("S")
 
-    extension.backend.move_window_to_workspace.assert_called_with("0xabc", "special:st-default", silent=True)
+    extension.backend.move_window_to_workspace.assert_called_once_with("0xabc", "special:st-S", silent=True)
     extension.backend.toggle_floating.assert_called_once_with("0xabc")
-    assert extension._was_floating["0xabc"] is False
+    assert extension._slots["S"].address == "0xabc"
+    assert extension._slots["S"].visible is False
+    assert extension._addr_to_stash == {"0xabc": "S"}
 
 
 @pytest.mark.asyncio
-async def test_stash_custom_name(extension):
-    """Stashing with a custom name uses that name."""
+async def test_stash_send_keeps_already_floating_window_floating(extension):
     extension.backend.execute_json.return_value = {
         "address": "0xabc",
+        "floating": True,
+        "workspace": {"id": 1, "name": "1"},
+    }
+
+    await extension.run_stash_send("S")
+
+    extension.backend.move_window_to_workspace.assert_called_once_with("0xabc", "special:st-S", silent=True)
+    extension.backend.toggle_floating.assert_not_called()
+    assert extension._slots["S"].was_floating is True
+
+
+@pytest.mark.asyncio
+async def test_stash_send_on_focused_visible_stash_releases_to_active_workspace(extension):
+    extension.backend.execute_json.return_value = {
+        "address": "0xabc",
+        "floating": False,
+        "workspace": {"id": 1, "name": "1"},
+    }
+    await extension.run_stash_send("S")
+    await extension.run_stash_toggle("S")
+
+    extension.backend.reset_mock()
+    extension.backend.execute_json.return_value = {
+        "address": "0xabc",
+        "floating": True,
+        "workspace": {"id": 1, "name": "1"},
+    }
+
+    await extension.run_stash_send("S")
+
+    extension.backend.pin_window.assert_called_once_with("0xabc")
+    extension.backend.move_window_to_workspace.assert_called_once_with("0xabc", "1", silent=True)
+    extension.backend.toggle_floating.assert_called_once_with("0xabc")
+    extension.backend.focus_window.assert_called_once_with("0xabc")
+    assert extension._slots["S"].address == ""
+    assert extension._slots["S"].visible is False
+    assert extension._addr_to_stash == {}
+
+
+@pytest.mark.asyncio
+async def test_stash_toggle_show_moves_window_to_active_workspace_and_pins_it(extension):
+    extension.backend.execute_json.return_value = {
+        "address": "0xabc",
+        "floating": False,
+        "workspace": {"id": 1, "name": "1"},
+    }
+    await extension.run_stash_send("S")
+
+    extension.backend.reset_mock()
+
+    await extension.run_stash_toggle("S")
+
+    extension.backend.move_window_to_workspace.assert_called_once_with("0xabc", "1", silent=True)
+    extension.backend.resize_window.assert_called_once_with("0xabc", 240, 432)
+    extension.backend.move_window.assert_called_once_with("0xabc", 770, 196)
+    extension.backend.pin_window.assert_called_once_with("0xabc")
+    extension.backend.focus_window.assert_called_once_with("0xabc")
+    assert extension._slots["S"].visible is True
+
+
+@pytest.mark.asyncio
+async def test_stash_toggle_hide_unpins_and_returns_window_to_hidden_workspace(extension):
+    extension.backend.execute_json.return_value = {
+        "address": "0xabc",
+        "floating": False,
+        "workspace": {"id": 1, "name": "1"},
+    }
+    await extension.run_stash_send("S")
+    await extension.run_stash_toggle("S")
+
+    extension.backend.reset_mock()
+
+    await extension.run_stash_toggle("S")
+
+    extension.backend.pin_window.assert_called_once_with("0xabc")
+    extension.backend.move_window_to_workspace.assert_called_once_with("0xabc", "special:st-S", silent=True)
+    assert extension._slots["S"].visible is False
+
+
+@pytest.mark.asyncio
+async def test_stash_toggle_restores_saved_geometry_when_configured(extension):
+    extension.backend.execute_json.return_value = {
+        "address": "0xdef",
+        "floating": True,
+        "workspace": {"id": 1, "name": "1"},
+    }
+    await extension.run_stash_send("C")
+
+    await extension.run_stash_toggle("C")
+
+    extension.backend.reset_mock()
+    extension.backend.get_client_props.return_value = {"size": [333, 222], "at": [500, 250]}
+
+    await extension.run_stash_toggle("C")
+
+    extension.backend.reset_mock()
+
+    await extension.run_stash_toggle("C")
+
+    extension.backend.resize_window.assert_called_once_with("0xdef", 333, 222)
+    extension.backend.move_window.assert_called_once_with("0xdef", 500, 250)
+
+
+@pytest.mark.asyncio
+async def test_stash_send_replaces_existing_window_in_same_stash(extension):
+    extension.backend.execute_json.return_value = {
+        "address": "0xold",
+        "floating": False,
+        "workspace": {"id": 1, "name": "1"},
+    }
+    await extension.run_stash_send("S")
+
+    extension.backend.reset_mock()
+    extension.backend.execute_json.return_value = {
+        "address": "0xnew",
         "floating": False,
         "workspace": {"id": 2, "name": "2"},
     }
 
-    await extension.run_stash("work")
-
-    extension.backend.move_window_to_workspace.assert_called_with("0xabc", "special:st-work", silent=True)
-
-
-@pytest.mark.asyncio
-async def test_stash_already_floating_no_toggle(extension):
-    """Stashing an already-floating window does not toggle floating."""
-    extension.backend.execute_json.return_value = {
-        "address": "0xabc",
-        "floating": True,
-        "workspace": {"id": 1, "name": "1"},
-    }
-
-    await extension.run_stash()
-
-    extension.backend.move_window_to_workspace.assert_called_with("0xabc", "special:st-default", silent=True)
-    extension.backend.toggle_floating.assert_not_called()
-    assert extension._was_floating["0xabc"] is True
-
-
-# -- run_stash: unstashing --
-
-
-@pytest.mark.asyncio
-async def test_unstash_moves_window_back(extension):
-    """Unstashing a stashed tiled window restores it to the active workspace and restores tiled state."""
-    extension._was_floating["0xabc"] = False
-    extension.backend.execute_json.return_value = {
-        "address": "0xabc",
-        "workspace": {"id": -99, "name": "special:st-default"},
-    }
-
-    await extension.run_stash()
-
-    extension.backend.move_window_to_workspace.assert_called_with("0xabc", extension.state.active_workspace, silent=True)
-    extension.backend.focus_window.assert_called_with("0xabc")
-    extension.backend.toggle_floating.assert_called_once_with("0xabc")
-    assert "0xabc" not in extension._was_floating
-
-
-@pytest.mark.asyncio
-async def test_unstash_from_different_stash(extension):
-    """A window in stash-work is unstashed even when called with default name."""
-    extension._was_floating["0xdef"] = False
-    extension.backend.execute_json.return_value = {
-        "address": "0xdef",
-        "workspace": {"id": -42, "name": "special:st-work"},
-    }
-
-    # Called without arguments (name="default"), but window is in stash-work
-    await extension.run_stash()
-
-    extension.backend.move_window_to_workspace.assert_called_with("0xdef", extension.state.active_workspace, silent=True)
-    extension.backend.focus_window.assert_called_with("0xdef")
-
-
-@pytest.mark.asyncio
-async def test_unstash_originally_floating_stays_floating(extension):
-    """Unstashing a window that was originally floating does not toggle floating."""
-    extension._was_floating["0xabc"] = True
-    extension.backend.execute_json.return_value = {
-        "address": "0xabc",
-        "workspace": {"id": -99, "name": "special:st-default"},
-    }
-
-    await extension.run_stash()
-
-    extension.backend.toggle_floating.assert_not_called()
-    assert "0xabc" not in extension._was_floating
-
-
-# -- run_stash: edge cases --
-
-
-@pytest.mark.asyncio
-async def test_stash_no_active_window(extension):
-    """No-op when there is no active window."""
-    extension.backend.execute_json.return_value = {
-        "address": "",
-        "workspace": {"id": 0, "name": ""},
-    }
-
-    await extension.run_stash()
-
-    extension.backend.move_window_to_workspace.assert_not_called()
-    assert get_executed_commands(extension.backend.execute) == []
-
-
-@pytest.mark.asyncio
-async def test_stash_on_shown_window_removes_from_stash(extension):
-    """Calling stash on a shown window removes it from the stash and restores tiled state."""
-    extension._was_floating["0xaaa"] = False
-    extension._was_floating["0xbbb"] = False
-    extension.get_clients.return_value = [
-        {"address": "0xaaa"},
-        {"address": "0xbbb"},
-    ]
-    await extension.run_stash_toggle()  # show both
-    extension.backend.reset_mock()
-
-    # User focuses 0xaaa and calls stash
-    extension.backend.execute_json.return_value = {
-        "address": "0xaaa",
-        "workspace": {"id": 1, "name": "1"},
-    }
-
-    await extension.run_stash()
-
-    # Window stays on the active workspace — no move commands
-    extension.backend.move_window_to_workspace.assert_not_called()
-    # Floating was restored (was originally tiled)
-    extension.backend.toggle_floating.assert_called_once_with("0xaaa")
-    # Removed from tracking, but stash is still visible (0xbbb remains)
-    assert "0xaaa" not in extension._shown_addresses["default"]
-    assert "0xbbb" in extension._shown_addresses["default"]
-    assert extension._visible["default"] is True
-    assert "0xaaa" not in extension._was_floating
-
-
-@pytest.mark.asyncio
-async def test_stash_on_shown_window_originally_floating_no_toggle(extension):
-    """Removing a shown window that was originally floating does not toggle floating."""
-    extension._was_floating["0xaaa"] = True
-    extension.get_clients.return_value = [
-        {"address": "0xaaa"},
-    ]
-    await extension.run_stash_toggle()  # show
-    extension.backend.reset_mock()
-
-    extension.backend.execute_json.return_value = {
-        "address": "0xaaa",
-        "workspace": {"id": 1, "name": "1"},
-    }
-
-    await extension.run_stash()
-
-    extension.backend.toggle_floating.assert_not_called()
-    assert "0xaaa" not in extension._was_floating
-
-
-@pytest.mark.asyncio
-async def test_stash_on_last_shown_window_clears_visibility(extension):
-    """Removing the last shown window also clears the stash visibility state."""
-    extension._was_floating["0xaaa"] = False
-    extension.get_clients.return_value = [
-        {"address": "0xaaa"},
-    ]
-    await extension.run_stash_toggle()  # show
-    extension.backend.reset_mock()
-
-    extension.backend.execute_json.return_value = {
-        "address": "0xaaa",
-        "workspace": {"id": 1, "name": "1"},
-    }
-
-    await extension.run_stash()
-
-    extension.backend.move_window_to_workspace.assert_not_called()
-    assert extension._visible.get("default", False) is False
-    assert "default" not in extension._shown_addresses
-
-
-# -- run_stash_toggle --
-
-
-@pytest.mark.asyncio
-async def test_stash_toggle_show_moves_windows_to_active_workspace(extension):
-    """Showing a stash moves windows from the special workspace to the active workspace."""
-    extension.get_clients.return_value = [
-        {"address": "0xaaa"},
-        {"address": "0xbbb"},
-    ]
-
-    await extension.run_stash_toggle()
-
-    extension.get_clients.assert_called_with(workspace="special:st-default")
-    extension.backend.move_window_to_workspace.assert_any_call("0xaaa", "1", silent=True)
-    extension.backend.move_window_to_workspace.assert_any_call("0xbbb", "1", silent=True)
-
-
-@pytest.mark.asyncio
-async def test_stash_toggle_show_all_moves_are_silent(extension):
-    """All window moves use movetoworkspacesilent."""
-    extension.get_clients.return_value = [
-        {"address": "0xaaa"},
-        {"address": "0xbbb"},
-    ]
-
-    await extension.run_stash_toggle()
+    await extension.run_stash_send("S")
 
     calls = extension.backend.move_window_to_workspace.call_args_list
-    assert calls[0].args == ("0xaaa", "1")
+    assert calls[0].args == ("0xold", "1")
     assert calls[0].kwargs == {"silent": True}
-    assert calls[1].args == ("0xbbb", "1")
+    assert calls[1].args == ("0xnew", "special:st-S")
     assert calls[1].kwargs == {"silent": True}
     extension.backend.focus_window.assert_not_called()
+    assert extension.backend.toggle_floating.call_args_list[0].args == ("0xold",)
+    assert extension.backend.toggle_floating.call_args_list[1].args == ("0xnew",)
+    assert extension._slots["S"].address == "0xnew"
+    assert extension._addr_to_stash == {"0xnew": "S"}
 
 
 @pytest.mark.asyncio
-async def test_stash_toggle_show_does_not_toggle_floating(extension):
-    """Showing a stash does not toggle floating — floating is set at stash time."""
-    extension.get_clients.return_value = [
-        {"address": "0xaaa"},
-    ]
-
-    await extension.run_stash_toggle()
-
-    extension.backend.toggle_floating.assert_not_called()
-
-
-@pytest.mark.asyncio
-async def test_stash_toggle_show_no_windows_is_noop(extension):
-    """Showing an empty stash does nothing."""
-    extension.get_clients.return_value = []
-
-    await extension.run_stash_toggle()
-
-    extension.backend.move_window_to_workspace.assert_not_called()
-
-
-@pytest.mark.asyncio
-async def test_stash_toggle_show_custom_name(extension):
-    """Showing a custom-named stash queries the right workspace."""
-    extension.get_clients.return_value = [
-        {"address": "0xaaa"},
-    ]
-
-    await extension.run_stash_toggle("music")
-
-    extension.get_clients.assert_called_with(workspace="special:st-music")
-    extension.backend.move_window_to_workspace.assert_called_with("0xaaa", "1", silent=True)
-
-
-@pytest.mark.asyncio
-async def test_stash_toggle_hide_moves_windows_back(extension):
-    """Hiding a shown stash moves tracked windows back to the special workspace."""
-    extension.get_clients.return_value = [
-        {"address": "0xaaa"},
-        {"address": "0xbbb"},
-    ]
-
-    # Show first
-    await extension.run_stash_toggle()
-    extension.backend.reset_mock()
-
-    # Then hide
-    await extension.run_stash_toggle()
-
-    extension.backend.move_window_to_workspace.assert_any_call("0xaaa", "special:st-default")
-    extension.backend.move_window_to_workspace.assert_any_call("0xbbb", "special:st-default")
-
-
-@pytest.mark.asyncio
-async def test_stash_toggle_hide_clears_tracking(extension):
-    """After hiding, the stash is no longer considered visible."""
-    extension.get_clients.return_value = [
-        {"address": "0xaaa"},
-    ]
-
-    await extension.run_stash_toggle()  # show
-    assert extension._visible["default"] is True
-
-    await extension.run_stash_toggle()  # hide
-    assert extension._visible["default"] is False
-    assert "default" not in extension._shown_addresses
-
-
-# -- style tagging --
-
-
-@pytest.mark.asyncio
-async def test_on_reload_clears_old_rules_and_registers_new(styled_extension):
-    """on_reload clears old rules then registers tag-matched window rules."""
-    await styled_extension.on_reload()
-
-    commands = get_executed_commands(styled_extension.backend.execute)
-    assert ("windowrule tag -stashed", {"base_command": "keyword"}) in commands
-    assert ("windowrule border_color rgb(ec8800), match:tag stashed", {"base_command": "keyword"}) in commands
-    assert ("windowrule border_size 3, match:tag stashed", {"base_command": "keyword"}) in commands
-
-
-@pytest.mark.asyncio
-async def test_on_reload_clears_rules_even_when_style_empty(extension):
-    """on_reload clears old rules even when style config is empty."""
-    await extension.on_reload()
-
-    commands = get_executed_commands(extension.backend.execute)
-    assert commands == [("windowrule tag -stashed", {"base_command": "keyword"})]
-
-
-@pytest.mark.asyncio
-async def test_stash_tags_window_when_style_configured(styled_extension):
-    """Stashing a window tags it when style is configured."""
-    styled_extension.backend.execute_json.return_value = {
-        "address": "0xabc",
-        "floating": True,
-        "workspace": {"id": 1, "name": "1"},
-    }
-
-    await styled_extension.run_stash()
-
-    commands = get_executed_commands(styled_extension.backend.execute)
-    assert commands == [("tagwindow +stashed address:0xabc", {})]
-
-
-@pytest.mark.asyncio
-async def test_stash_does_not_tag_without_style(extension):
-    """Stashing a window does not tag it when style is empty."""
+async def test_closewindow_clears_stash_tracking(extension):
     extension.backend.execute_json.return_value = {
         "address": "0xabc",
-        "floating": True,
+        "floating": False,
         "workspace": {"id": 1, "name": "1"},
     }
-
-    await extension.run_stash()
-
-    commands = get_executed_commands(extension.backend.execute)
-    assert all("tagwindow" not in cmd for cmd, _ in commands)
-
-
-@pytest.mark.asyncio
-async def test_unstash_untags_window_when_style_configured(styled_extension):
-    """Unstashing a window from special workspace untags it."""
-    styled_extension.backend.execute_json.return_value = {
-        "address": "0xabc",
-        "workspace": {"id": -99, "name": "special:st-default"},
-    }
-
-    await styled_extension.run_stash()
-
-    commands = get_executed_commands(styled_extension.backend.execute)
-    assert commands == [("tagwindow -stashed address:0xabc", {})]
-
-
-@pytest.mark.asyncio
-async def test_stash_on_shown_window_untags_when_style_configured(styled_extension):
-    """Calling stash on a shown window untags it when style is configured."""
-    styled_extension._was_floating["0xaaa"] = True
-    styled_extension.get_clients.return_value = [
-        {"address": "0xaaa"},
-    ]
-    await styled_extension.run_stash_toggle()  # show
-    styled_extension.backend.reset_mock()
-
-    styled_extension.backend.execute_json.return_value = {
-        "address": "0xaaa",
-        "workspace": {"id": 1, "name": "1"},
-    }
-
-    await styled_extension.run_stash()
-
-    commands = get_executed_commands(styled_extension.backend.execute)
-    assert commands == [("tagwindow -stashed address:0xaaa", {})]
-
-
-# -- event_closewindow --
-
-
-@pytest.mark.asyncio
-async def test_closewindow_removes_from_was_floating(extension):
-    """Closing a stashed window removes it from floating state tracking."""
-    extension._was_floating["0xabc"] = False
+    await extension.run_stash_send("S")
 
     await extension.event_closewindow("abc")
 
-    assert "0xabc" not in extension._was_floating
+    assert extension._slots["S"].address == ""
+    assert extension._slots["S"].visible is False
+    assert extension._addr_to_stash == {}
 
 
 @pytest.mark.asyncio
-async def test_closewindow_removes_from_shown_addresses(extension):
-    """Closing a shown window removes it from the group but keeps the group alive."""
-    extension._shown_addresses["default"] = ["0xaaa", "0xbbb"]
-    extension._visible["default"] = True
+async def test_exit_releases_hidden_stash_to_active_workspace(extension):
+    extension.backend.execute_json.return_value = {
+        "address": "0xabc",
+        "floating": False,
+        "workspace": {"id": 1, "name": "1"},
+    }
+    await extension.run_stash_send("S")
 
-    await extension.event_closewindow("aaa")
+    extension.backend.reset_mock()
 
-    assert "0xaaa" not in extension._shown_addresses["default"]
-    assert "0xbbb" in extension._shown_addresses["default"]
-    assert extension._visible["default"] is True
+    await extension.exit()
 
-
-@pytest.mark.asyncio
-async def test_closewindow_clears_group_when_last_shown_window_closed(extension):
-    """Closing the last shown window in a group clears the group and visibility."""
-    extension._shown_addresses["default"] = ["0xaaa"]
-    extension._visible["default"] = True
-
-    await extension.event_closewindow("aaa")
-
-    assert "default" not in extension._shown_addresses
-    assert extension._visible["default"] is False
+    extension.backend.pin_window.assert_not_called()
+    extension.backend.move_window_to_workspace.assert_called_once_with("0xabc", "1", silent=True)
+    extension.backend.toggle_floating.assert_called_once_with("0xabc")
+    extension.backend.focus_window.assert_not_called()
+    assert extension._slots["S"].address == ""
 
 
-@pytest.mark.asyncio
-async def test_closewindow_noop_for_unknown_window(extension):
-    """Closing an untracked window does not error or change state."""
-    extension._was_floating["0xother"] = True
-    extension._shown_addresses["default"] = ["0xother"]
-    extension._visible["default"] = True
+def test_validate_config_static_accepts_named_stash_sections():
+    errors = Extension.validate_config_static("stash", CONFIG)
 
-    await extension.event_closewindow("unknown")
-
-    assert extension._was_floating == {"0xother": True}
-    assert extension._shown_addresses == {"default": ["0xother"]}
-    assert extension._visible["default"] is True
+    assert errors == []
 
 
-@pytest.mark.asyncio
-async def test_closewindow_cleans_both_was_floating_and_shown(extension):
-    """Closing a shown window cleans up both _was_floating and _shown_addresses."""
-    extension._was_floating["0xaaa"] = False
-    extension._shown_addresses["default"] = ["0xaaa"]
-    extension._visible["default"] = True
+def test_validate_config_static_rejects_non_table_sections():
+    errors = Extension.validate_config_static("stash", {"S": "bad"})
 
-    await extension.event_closewindow("aaa")
-
-    assert "0xaaa" not in extension._was_floating
-    assert "default" not in extension._shown_addresses
-    assert extension._visible["default"] is False
+    assert errors == ["[stash] section 'S' must be a table"]

--- a/tests/test_plugin_stash.py
+++ b/tests/test_plugin_stash.py
@@ -162,6 +162,33 @@ async def test_stash_toggle_restores_saved_geometry_when_configured(extension):
 
 
 @pytest.mark.asyncio
+async def test_stash_toggle_restores_saved_geometry_across_scaled_monitor_origins(extension):
+    scaled_monitor = {**MONITOR, "x": 1920, "y": 0, "scale": 2.0}
+    target_monitor = {**MONITOR, "x": 0, "y": 0, "scale": 1.0}
+    extension.backend.get_monitor_props.return_value = scaled_monitor
+    extension.backend.execute_json.return_value = {
+        "address": "0xdef",
+        "floating": True,
+        "workspace": {"id": 1, "name": "1"},
+    }
+    await extension.run_stash_send("C")
+    await extension.run_stash_toggle("C")
+
+    extension.backend.reset_mock()
+    extension.backend.get_client_props.return_value = {"size": [333, 222], "at": [2100, 120]}
+
+    await extension.run_stash_toggle("C")
+
+    extension.backend.reset_mock()
+    extension.backend.get_monitor_props.return_value = target_monitor
+
+    await extension.run_stash_toggle("C")
+
+    extension.backend.resize_window.assert_called_once_with("0xdef", 333, 222)
+    extension.backend.move_window.assert_called_once_with("0xdef", 180, 120)
+
+
+@pytest.mark.asyncio
 async def test_stash_send_replaces_existing_window_in_same_stash(extension):
     extension.backend.execute_json.return_value = {
         "address": "0xold",
@@ -189,6 +216,42 @@ async def test_stash_send_replaces_existing_window_in_same_stash(extension):
     assert extension.backend.toggle_floating.call_args_list[1].args == ("0xnew",)
     assert extension._slots["S"].address == "0xnew"
     assert extension._addr_to_stash == {"0xnew": "S"}
+
+
+@pytest.mark.asyncio
+async def test_stash_send_preserves_original_floating_state_when_moving_between_stashes(extension):
+    extension.backend.execute_json.return_value = {
+        "address": "0xabc",
+        "floating": False,
+        "workspace": {"id": 1, "name": "1"},
+    }
+    await extension.run_stash_send("S")
+    await extension.run_stash_toggle("S")
+
+    extension.backend.reset_mock()
+    extension.backend.execute_json.return_value = {
+        "address": "0xabc",
+        "floating": True,
+        "workspace": {"id": 1, "name": "1"},
+    }
+
+    await extension.run_stash_send("C")
+
+    extension.backend.toggle_floating.assert_not_called()
+    assert extension._slots["C"].was_floating is False
+
+    await extension.run_stash_toggle("C")
+
+    extension.backend.reset_mock()
+    extension.backend.execute_json.return_value = {
+        "address": "0xabc",
+        "floating": True,
+        "workspace": {"id": 1, "name": "1"},
+    }
+
+    await extension.run_stash_send("C")
+
+    extension.backend.toggle_floating.assert_called_once_with("0xabc")
 
 
 @pytest.mark.asyncio
@@ -225,6 +288,28 @@ async def test_exit_releases_hidden_stash_to_active_workspace(extension):
     extension.backend.toggle_floating.assert_called_once_with("0xabc")
     extension.backend.focus_window.assert_not_called()
     assert extension._slots["S"].address == ""
+
+
+@pytest.mark.asyncio
+async def test_on_reload_releases_removed_occupied_stash(extension):
+    extension.backend.execute_json.return_value = {
+        "address": "0xabc",
+        "floating": False,
+        "workspace": {"id": 1, "name": "1"},
+    }
+    await extension.run_stash_send("S")
+
+    extension.backend.reset_mock()
+    extension.config.clear()
+    extension.config.update({"C": CONFIG["C"]})
+
+    await extension.on_reload()
+
+    extension.backend.move_window_to_workspace.assert_called_once_with("0xabc", "1", silent=True)
+    extension.backend.toggle_floating.assert_called_once_with("0xabc")
+    extension.backend.focus_window.assert_not_called()
+    assert "S" not in extension._slots
+    assert extension._addr_to_stash == {}
 
 
 def test_validate_config_static_accepts_named_stash_sections():


### PR DESCRIPTION
Rework stash into named window slots like S and C.
Add stash_send to send or release a window, and stash_toggle to show or hide it as a pinned overlay.
Keep the stash window visible across workspaces, preserve its adjusted size/position, and update tests/docs.

you can test it at:
https://github.com/Matrix030/pyprland/tree/feature/Matrix030-stash

i've been using this implementation for over 2 months now