### PR TITLE
Feature/notify-send (Hyprland)

### DIFF
--- a/pyprland/adapters/hyprland.py
+++ b/pyprland/adapters/hyprland.py
@@ -9,8 +9,9 @@ from logging import Logger
 from typing import Any, cast
 
 from ..constants import DEFAULT_NOTIFICATION_DURATION_MS
-from ..ipc import get_response, hyprctl_connection, retry_on_reset
+from ..ipc import get_notify_method, get_response, hyprctl_connection, retry_on_reset
 from ..models import ClientInfo, MonitorInfo
+from ..utils import notify_send
 from .backend import EnvironmentBackend
 
 
@@ -190,5 +191,8 @@ class HyprlandBackend(EnvironmentBackend):
             icon: Icon code (-1 default, 0 error, 1 info)
             log: Logger to use for this operation
         """
-        # This mirrors ipc.notify logic for Hyprland
-        await self.execute(f"{icon} {duration} rgb({color})  {text}", log=log, base_command="notify")
+        if get_notify_method() == "notify-send":
+            await notify_send(text, duration, color)
+        else:
+            # This mirrors ipc.notify logic for Hyprland
+            await self.execute(f"{icon} {duration} rgb({color})  {text}", log=log, base_command="notify")

--- a/pyprland/ipc.py
+++ b/pyprland/ipc.py
@@ -99,6 +99,15 @@ def set_notify_method(method: str) -> None:
     _state.notify_method = method
 
 
+def get_notify_method() -> str:
+    """Get the notification method.
+
+    Returns:
+        str: "auto", "native", "notify-send"
+    """
+    return _state.notify_method
+
+
 async def get_event_stream() -> tuple[asyncio.StreamReader, asyncio.StreamWriter]:
     """Return a new event socket connection."""
     if NIRI_SOCKET:

--- a/pyprland/version.py
+++ b/pyprland/version.py
@@ -1,3 +1,3 @@
 """Package version."""
 
-VERSION = "3.3.1-13"
+VERSION = "3.3.1-15"

--- a/pyprland/version.py
+++ b/pyprland/version.py
@@ -1,3 +1,3 @@
 """Package version."""
 
-VERSION = "3.3.1-10"
+VERSION = "3.3.1-13"


### PR DESCRIPTION
Fixes #237

Hi, this PR adds a way for backend adapters to check what notification method was set in the configuration file and also adds capability to have Hyprland use notify-send (via the notify_send utility) if set, otherwise falls back to the default behavior 