### PR TITLE
fix: remove stale address from registry on scratchpad window close

### DIFF
--- a/pyprland/plugins/scratchpads/events.py
+++ b/pyprland/plugins/scratchpads/events.py
@@ -98,6 +98,7 @@ class EventsMixin:
             # Reset state when the primary window is closed
             if scratch.full_address == addr:
                 scratch.visible = False
+                self.scratches.reset(scratch)  # remove stale addr from registry before clearing client_info
                 scratch.client_info = None
                 scratch.meta.initialized = False
 


### PR DESCRIPTION
Since ec85731, closing a scratchpad window clears client_info but leaves the address in ScratchDB._by_addr. When Hyprland reuses that address for a new unrelated window, pyprland mistakenly tries to initialize it as a scratchpad and fails with a KeyError.

Fix: call scratches.reset(scratch) before clearing client_info so the stale address is removed from the registry while it's still readable.