### PR TITLE
fix(build): include pypr-client when installing from source (#236)

### DIFF
--- a/hatch_build.py
+++ b/hatch_build.py
@@ -1,10 +1,18 @@
-"""Custom hatch build hook to compile the optional C client.
+"""Custom hatch build hook to compile the optional native C client.
 
-When the PYPRLAND_BUILD_NATIVE environment variable is set to "1", compiles
-client/pypr-client.c into a statically-linked native binary and includes it
-in a platform-specific wheel tagged for manylinux_2_17_x86_64.
+The ``pypr-client`` binary is a fast, dependency free drop in for the ``pypr``
+command. Whether it gets compiled and bundled into the wheel depends on the
+``PYPRLAND_BUILD_NATIVE`` environment variable:
 
-Without the env var the hook does nothing and the wheel stays pure-python.
+- unset (the default): best effort build. When a C compiler is available the
+  client is compiled (dynamically linked) and the wheel is tagged for the
+  building platform. With no compiler the build quietly falls back to a pure
+  python wheel. This is what source installs get (``pip`` or ``uv`` from an
+  sdist or a git checkout). See issue #236.
+- ``"1"``: force a statically linked binary in a wheel tagged
+  ``manylinux_2_17_x86_64``, suitable for publishing to PyPI.
+- ``"0"``: never compile, always produce a pure python wheel. Used to publish
+  the cross platform PyPI wheel, and as an escape hatch.
 """
 
 import os
@@ -79,17 +87,26 @@ class NativeClientBuildHook(BuildHookInterface):
     PLUGIN_NAME = "native-client"
 
     def initialize(self, version: str, build_data: dict) -> None:  # noqa: ARG002
-        """Compile the C client and include it in the wheel if successful.
+        """Compile the C client and include it in the wheel if appropriate.
 
-        Only runs when PYPRLAND_BUILD_NATIVE=1 is set and the build target
-        is a wheel.  The resulting wheel is tagged as manylinux so it can be
-        uploaded to PyPI.
+        Runs for every wheel build unless ``PYPRLAND_BUILD_NATIVE=0`` opts out.
+        With ``PYPRLAND_BUILD_NATIVE=1`` the binary is statically linked and the
+        wheel is tagged ``manylinux_2_17_x86_64`` for PyPI. Otherwise (the
+        default, for example source installs) it is a best effort, dynamically
+        linked build tagged for the running platform.
         """
         if self.target_name != "wheel":
             return
 
-        if os.environ.get("PYPRLAND_BUILD_NATIVE") != "1":
+        mode = os.environ.get("PYPRLAND_BUILD_NATIVE", "")
+        if mode == "0":  # explicit opt out, keep the wheel pure python
             return
+
+        # PYPRLAND_BUILD_NATIVE=1 produces a portable, statically linked binary
+        # for the published manylinux wheel. Any other value (including unset)
+        # does a best effort dynamic build so that source installs still ship
+        # the client (see issue #236).
+        static = mode == "1"
 
         source = Path(self.root) / "client" / "pypr-client.c"
         if not source.exists():
@@ -101,8 +118,8 @@ class NativeClientBuildHook(BuildHookInterface):
             self.app.display_warning("No C compiler found (set CC env var or install gcc/clang). Skipping native pypr-client build.")
             return
 
-        self.app.display_info(f"Compiling native client with {cc} (static)")
-        output, warning = _try_compile(cc, source, static=True)
+        self.app.display_info(f"Compiling native client with {cc}" + (" (static)" if static else ""))
+        output, warning = _try_compile(cc, source, static=static)
 
         if output is None:
             self.app.display_warning(warning)
@@ -114,6 +131,11 @@ class NativeClientBuildHook(BuildHookInterface):
         # {name}-{version}.data/scripts/ path in the wheel (PEP 427).
         build_data["shared_scripts"][str(output)] = "pypr-client"
 
-        # Mark the wheel as platform-specific with an explicit manylinux tag.
+        # The wheel now carries a native binary, so it is no longer pure python.
         build_data["pure_python"] = False
-        build_data["tag"] = MANYLINUX_TAG
+        if static:
+            # Portable binary, tag explicitly so it can be uploaded to PyPI.
+            build_data["tag"] = MANYLINUX_TAG
+        else:
+            # Built for this machine, let hatchling infer the platform tag.
+            build_data["infer_tag"] = True

--- a/scripts/make_release
+++ b/scripts/make_release
@@ -32,8 +32,9 @@ git tag $version
 git push
 
 rm -fr dist
-# Build sdist + pure Python wheel
-uv build
+# Build sdist + pure Python wheel (opt out of the native client so the
+# cross platform wheel stays pure python)
+PYPRLAND_BUILD_NATIVE=0 uv build
 # Build platform-specific wheel with statically compiled C client
 PYPRLAND_BUILD_NATIVE=1 uv build --wheel
 uv publish -u $PYPI_USERNAME -p $PYPI_PASSWORD

--- a/tests/test_native_client_build.py
+++ b/tests/test_native_client_build.py
@@ -1,0 +1,155 @@
+"""Tests for the native ``pypr-client`` build hook (``hatch_build.py``).
+
+Regression coverage for issue #236: a plain wheel build (what ``pip`` or ``uv``
+do when installing from an sdist or a git checkout) must still bundle
+``pypr-client`` when a C compiler is available, instead of quietly producing a
+pure python wheel. Only ``PYPRLAND_BUILD_NATIVE=0`` should opt out.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+# hatch_build.py lives at the repository root, next to pyproject.toml.
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT))
+
+
+def _ensure_hatchling_importable() -> None:
+    """Let hatch_build import even when the build backend isn't installed.
+
+    ``hatchling`` is only a build-system requirement (installed in isolated
+    build environments), so it is usually absent from the test venv. The hook
+    only needs ``BuildHookInterface`` as a base class, so stub the module chain
+    when the real one is unavailable.
+    """
+    path = "hatchling.builders.hooks.plugin.interface"
+    try:
+        __import__(path)
+        return
+    except ModuleNotFoundError:
+        pass
+
+    parts = path.split(".")
+    for i in range(1, len(parts) + 1):
+        name = ".".join(parts[:i])
+        sys.modules.setdefault(name, types.ModuleType(name))
+    sys.modules[path].BuildHookInterface = type("BuildHookInterface", (), {})
+
+
+_ensure_hatchling_importable()
+
+import hatch_build  # noqa: E402
+
+
+class _FakeApp:
+    """Stand-in for hatchling's build app, recording display calls."""
+
+    def __init__(self) -> None:
+        self.messages: list[tuple[str, str]] = []
+
+    def display_info(self, msg: str) -> None:
+        self.messages.append(("info", msg))
+
+    def display_warning(self, msg: str) -> None:
+        self.messages.append(("warning", msg))
+
+    def display_success(self, msg: str) -> None:
+        self.messages.append(("success", msg))
+
+
+def _make_hook() -> hatch_build.NativeClientBuildHook:
+    """Build a hook instance without invoking hatchling's real __init__."""
+    hook = hatch_build.NativeClientBuildHook.__new__(hatch_build.NativeClientBuildHook)
+    hook.root = str(ROOT)
+    hook.target_name = "wheel"
+    hook.app = _FakeApp()
+    return hook
+
+
+def _run(monkeypatch, env_value: str | None) -> dict:
+    """Run the hook with PYPRLAND_BUILD_NATIVE set to env_value (None=unset)."""
+    if env_value is None:
+        monkeypatch.delenv("PYPRLAND_BUILD_NATIVE", raising=False)
+    else:
+        monkeypatch.setenv("PYPRLAND_BUILD_NATIVE", env_value)
+    build_data: dict = {"shared_scripts": {}}
+    _make_hook().initialize("0", build_data)
+    return build_data
+
+
+def _has_compiler() -> bool:
+    return bool(hatch_build._find_compiler())
+
+
+def _scripts(build_data: dict) -> dict:
+    return build_data["shared_scripts"]
+
+
+def test_client_source_is_present() -> None:
+    """The C source the hook compiles must ship in the tree."""
+    assert (ROOT / "client" / "pypr-client.c").exists()
+
+
+def test_default_build_bundles_client(monkeypatch) -> None:
+    """Regression #236: an unset env var must still build the client.
+
+    Before the fix the client was opt-in (PYPRLAND_BUILD_NATIVE=1), so plain
+    source installs shipped a pure-python wheel with no pypr-client.
+    """
+    if not _has_compiler():
+        pytest.skip("no C compiler available")
+
+    build_data = _run(monkeypatch, None)
+    scripts = _scripts(build_data)
+
+    assert "pypr-client" in scripts.values(), "default build dropped pypr-client"
+    assert build_data.get("pure_python") is False
+    # A locally-built (non-portable) binary is tagged for this machine, not manylinux.
+    assert build_data.get("infer_tag") is True
+    assert "tag" not in build_data
+
+    (compiled,) = [Path(p) for p, name in scripts.items() if name == "pypr-client"]
+    assert compiled.exists() and compiled.stat().st_size > 0
+
+
+def test_opt_out_keeps_wheel_pure(monkeypatch) -> None:
+    """PYPRLAND_BUILD_NATIVE=0 must skip compilation entirely."""
+    build_data = _run(monkeypatch, "0")
+    assert _scripts(build_data) == {}
+    assert "pure_python" not in build_data
+    assert "tag" not in build_data
+    assert "infer_tag" not in build_data
+
+
+def test_native_build_tags_manylinux(monkeypatch) -> None:
+    """PYPRLAND_BUILD_NATIVE=1 must produce a manylinux-tagged wheel."""
+    if not _has_compiler():
+        pytest.skip("no C compiler available")
+
+    # A static build needs a static libc, which isn't present everywhere;
+    # only assert the tagging contract when it can actually link.
+    source = ROOT / "client" / "pypr-client.c"
+    probe, _warning = hatch_build._try_compile(hatch_build._find_compiler(), source, static=True)
+    if probe is None:
+        pytest.skip("static linking unavailable on this system")
+
+    build_data = _run(monkeypatch, "1")
+    assert "pypr-client" in _scripts(build_data).values()
+    assert build_data.get("pure_python") is False
+    assert build_data.get("tag") == hatch_build.MANYLINUX_TAG
+    assert "infer_tag" not in build_data
+
+
+def test_non_wheel_target_is_noop(monkeypatch) -> None:
+    """The hook must do nothing for non-wheel targets (e.g. sdist)."""
+    monkeypatch.delenv("PYPRLAND_BUILD_NATIVE", raising=False)
+    hook = _make_hook()
+    hook.target_name = "sdist"
+    build_data: dict = {"shared_scripts": {}}
+    hook.initialize("0", build_data)
+    assert _scripts(build_data) == {}

--- a/tests/test_native_client_build.py
+++ b/tests/test_native_client_build.py
@@ -37,7 +37,12 @@ def _ensure_hatchling_importable() -> None:
     parts = path.split(".")
     for i in range(1, len(parts) + 1):
         name = ".".join(parts[:i])
-        sys.modules.setdefault(name, types.ModuleType(name))
+        module = sys.modules.get(name)
+        if module is None:
+            module = types.ModuleType(name)
+            sys.modules[name] = module
+        if i < len(parts):
+            module.__path__ = []
     sys.modules[path].BuildHookInterface = type("BuildHookInterface", (), {})
 
 


### PR DESCRIPTION
Fixes #236.

I ran into this installing from a git checkout: `pypr-client` was missing. It turns out any source install is affected.

The native client only gets compiled when `PYPRLAND_BUILD_NATIVE=1`. That flag is set in `scripts/make_release` for the manylinux wheel, but a plain `uv build`, or a pip/uv install from an sdist or git archive, never sets it. So the build hook skips compilation and you get a pure python wheel with no `pypr-client`. Installing from PyPI hides it, because pip pulls the prebuilt manylinux wheel that already contains the binary, which is probably why it was hard to reproduce.

The gate came in with cb945df (the 3.3.0 commit). Before that, the hook always tried to compile when a compiler was present.

This restores that behaviour and adds an explicit way to turn it off:

* no env var (default): best effort compile, dynamically linked, wheel tagged for the local platform. This is what source installs get.
* `PYPRLAND_BUILD_NATIVE=1`: statically linked, manylinux tag, for the PyPI release. Unchanged.
* `PYPRLAND_BUILD_NATIVE=0`: never compile, stay pure python. `make_release` now uses this for the cross platform wheel, so the set of wheels published to PyPI is exactly the same as before.

How I checked it locally:

* `uv build --wheel` with no flag now produces a wheel containing `pyprland-3.4.1.data/scripts/pypr-client`, and the binary runs.
* `PYPRLAND_BUILD_NATIVE=1 uv build --wheel` still produces the manylinux wheel with the static binary.
* `PYPRLAND_BUILD_NATIVE=0 uv build` produces the pure `py3-none-any` wheel.
* the sdist still ships `client/pypr-client.c` and `hatch_build.py`, so it can compile on the user's machine.
* added `tests/test_native_client_build.py` covering the three modes (it skips when there is no C compiler).

