### PR TITLE
Fix scratchpad recycled addresses

### DIFF
--- a/pyprland/plugins/scratchpads/events.py
+++ b/pyprland/plugins/scratchpads/events.py
@@ -246,6 +246,15 @@ class EventsMixin:
         """
         addr, _wrkspc, _kls, _title = params.split(",", 3)
         item = self.scratches.get(addr=addr)
+        if item is not None and not item.have_address("0x" + addr):
+            # Hyprland recycles the window handle address of a destroyed window.
+            # A freshly opened, unrelated window can therefore reuse the address
+            # of a scratchpad that no longer owns it, leaving a stale entry in
+            # the address registry. Drop it and treat the window as unrelated
+            # instead of trying (and failing) to initialize it as a scratchpad.
+            self.log.debug("Dropping stale registry entry for 0x%s (was scratch %r)", addr, item.uid)
+            self.scratches.clear(addr=addr)
+            item = None
         respawned = list(self.scratches.get_by_state("respawned"))
 
         if item:

--- a/tests/test_plugin_scratchpads.py
+++ b/tests/test_plugin_scratchpads.py
@@ -537,3 +537,50 @@ async def test_command_serialization(scratchpads, subprocess_shell_mock, server_
         # First end should come before second start
         assert ends[0] < starts[1], f"Commands interleaved! Order: {execution_order}"
     # If less than 4 entries, second command may have been a no-op (already hidden) - that's fine
+
+
+@pytest.mark.asyncio
+async def test_openwindow_recycled_address(scratchpads, subprocess_shell_mock, server_fixture):
+    """A window reusing a destroyed scratchpad's recycled address must be ignored.
+
+    Hyprland reuses the window-handle address of a destroyed window. If a
+    scratchpad window is gone but a stale entry still lingers in the address
+    registry (e.g. cleared during a respawn before the close event is handled),
+    an unrelated window opening with that recycled address must not be mistaken
+    for the scratchpad. Regression test for the
+    ``scratchpads::event_openwindow: 'Client window  not found'`` error.
+    """
+    mocks.json_commands_result["clients"] = CLIENT_CONFIG
+
+    # Spawn and map the scratchpad so it gets registered by its address.
+    await mocks.pypr("toggle term")
+    await wait_called(mocks.hyprctl, count=2)
+    await _send_window_events()
+    await asyncio.sleep(0.1)
+    await mocks.wait_queues()
+
+    plugin = mocks.pyprland_instance.plugins["scratchpads"]
+    term = plugin.scratches.get("term")
+    assert term is not None
+    assert plugin.scratches.get(addr="12345677890") is term
+
+    # Simulate the race: the scratchpad window is gone (client info cleared, as
+    # happens on respawn/reset) while its address still lingers in the registry.
+    term.client_info = None
+    term.meta.initialized = False
+    assert plugin.scratches.get(addr="12345677890") is term
+
+    mocks.hyprctl.reset_mock()
+
+    # An unrelated window opens reusing the recycled address.
+    # Real Hyprland sends the bare hex address (no "0x"/"address:" prefix).
+    await mocks.send_event("openwindow>>12345677890,1,firefox,Mozilla Firefox")
+    await asyncio.sleep(0.1)
+    await mocks.wait_queues()
+
+    # No error notification must be emitted ...
+    notifies = [c for c in mocks.hyprctl.call_args_list if c.kwargs.get("base_command") == "notify"]
+    assert not notifies, f"unexpected notification(s): {notifies}"
+
+    # ... and the stale registry entry must have been purged.
+    assert plugin.scratches.get(addr="12345677890") is None


### PR DESCRIPTION
Contributes to #242

I kept getting these random `event_openwindow: 'Client window  not found'` errors whenever I spawned in windows (kitty, ms-teams, zed, anything pretty much)
- i let the clanker dig into it and it found: 
   ```
   Hyprland recycles window addresses, so a brand new window can land on the address of a 
   dead scratchpad that's still sitting in pyprland's `_by_addr` registry. 
   pyprland sees the match, assumes it's the scratchpad, tries to init it, and fails
   ```
- to fix this: before treating an `openwindow` hit as a scratchpad, we check that the scratch actually still owns that address (`have_address`). If it doesn't, it's a stale ghost entry, so we drop it from the registry and move on
- this extends #242 (which only cleaned up on window close) by validating at the point of use, so it doesn't matter how the entry went stale in the first place